### PR TITLE
Update Github workflow to include dev branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     # Only run when there are changes under proto dir
     paths:
@@ -37,7 +38,7 @@ jobs:
   bsr-push-draft:
     runs-on: ubuntu-latest
     needs: buf-lint
-    if: github.ref == 'refs/heads/draft'
+    if: ${{ (github.ref == 'refs/heads/draft') || (github.ref == 'refs/heads/dev') }}
     environment: draft
     steps:
       - name: Checkout the repo
@@ -52,6 +53,10 @@ jobs:
             # Install the defined version
             sudo ./scripts/buf-installer.sh --version=${{ env.buf_version}}
           fi
+      - name: Update URLs with branch name
+        run: |
+          # Add branch name to URLs
+          find proto -type f -name '*.proto' -print0 | xargs -0 -I {} ./scripts/replace_url.sh {} ${github.ref_name}
       - name: Push to buf.build
         uses: bufbuild/buf-push-action@v1
         with:
@@ -63,7 +68,7 @@ jobs:
   diagrams:
     runs-on: ubuntu-latest
     needs: buf-lint
-    if: github.ref == 'refs/heads/draft'
+    if: ${{ (github.ref == 'refs/heads/draft') || (github.ref == 'refs/heads/dev') }}
     steps:
       # Setup environment
       - name: Checkout the repo
@@ -105,4 +110,4 @@ jobs:
       - name: Upload Diagrams
         run: |
           # '-J' options is to set Content-Encoding to gzip
-          gsutil -m rsync -J -R -d gen/diagrams gs://docs-cmp-files/diagrams
+          gsutil -m rsync -J -R -d gen/diagrams gs://docs-cmp-files/diagrams/${github.ref_name}

--- a/proto/cmp/types/v1alpha1/search.proto
+++ b/proto/cmp/types/v1alpha1/search.proto
@@ -55,41 +55,6 @@ message SearchParameters {
   string search_description_audio_url = 10;
 }
 
-message SearchParametersSpecific {
-  // Geo Location for search, set only one of the fields at once.
-  //
-  // This one of field enforces only one of the fields below. They all share memory,
-  // setting one will remove the others.
-  oneof geo_location {
-    // FIXME: Do we need a list of location code here? Other fields are not lists.
-    LocationCodes location_codes = 9;
-
-    // Single geographic point represented by two double fields.
-    Coordinate location_coordinate = 10;
-
-    // Geo tree type, representted by Country, Region, and City_or_Resort.
-    GeoTree location_geo_tree = 11;
-
-    // Geo circle. Represented by a coordinate and a distance for radius.
-    GeoCircle location_geo_circle = 12;
-
-    // Geo polygon. Represented by a list of coordinate points.
-    GeoPolygon location_geo_polygon = 13;
-  }
-
-  // Mealplan codes
-  repeated MealPlan meal_plan_codes = 16;
-
-  // Rate plans
-  repeated RatePlan rate_plan = 17;
-
-  // Rate Rules
-  //
-  // FIXME: Did we decided to remove this from SearchParameters? Maybe some
-  // users/distributors would want to search for only RESELLABLE offers?
-  repeated RateRule rate_rules = 18;
-}
-
 // Search Response Metadata
 message SearchRequestMetadata {
   // An identifier for external sessions, aiding in tracking and continuity across

--- a/proto/cmp/types/v1alpha1/search.proto
+++ b/proto/cmp/types/v1alpha1/search.proto
@@ -6,9 +6,6 @@ import "cmp/types/v1alpha1/country.proto";
 import "cmp/types/v1alpha1/currency.proto";
 import "cmp/types/v1alpha1/filter.proto";
 import "cmp/types/v1alpha1/language.proto";
-import "cmp/types/v1alpha1/location.proto";
-import "cmp/types/v1alpha1/meal_plan.proto";
-import "cmp/types/v1alpha1/rate.proto";
 import "cmp/types/v1alpha1/sorting.proto";
 import "cmp/types/v1alpha1/uuid.proto";
 

--- a/scripts/replace_url.sh
+++ b/scripts/replace_url.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Check if two arguments are given
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <file_path> <branch>"
+    exit 1
+fi
+
+file_path=$1
+branch=$2
+old_url="https:\/\/storage.googleapis.com\/docs-cmp-files\/diagrams"
+new_url="https:\/\/storage.googleapis.com\/docs-cmp-files\/diagrams\/${branch}"
+
+# Check if the file exists
+if [ ! -f "$file_path" ]; then
+    echo "Error: File does not exist."
+    exit 1
+fi
+
+# Replace the URL
+sed -i "s/$old_url/$new_url/g" "$file_path"
+
+echo "URL updated successfully with ${branch} in $file_path"


### PR DESCRIPTION
This PR updates github workflow to include `dev` branch in deployment to buf.build. 

It also adds a script to update diagram URLs to specified branch name so we can have different diagrams for different branches on buf.build.