### PR TITLE
Additional codes update

### DIFF
--- a/proto/cmp/services/accommodation/v1alpha/info.proto
+++ b/proto/cmp/services/accommodation/v1alpha/info.proto
@@ -6,6 +6,7 @@ import "cmp/services/accommodation/v1alpha/property_types.proto";
 import "cmp/types/v1alpha/common.proto";
 import "cmp/types/v1alpha/language.proto";
 import "google/protobuf/timestamp.proto";
+import "cmp/types/v1alpha/product_code.proto";
 
 message AccommodationProductInfoRequest {
   // Message header
@@ -18,7 +19,7 @@ message AccommodationProductInfoRequest {
   repeated cmp.types.v1alpha.Language languages = 3;
 
   // Property codes
-  repeated string property_codes = 4;
+  repeated cmp.types.v1alpha.SupplierProductCodeProductCode supplier_codes = 4;
 }
 
 message AccommodationProductInfoResponse {

--- a/proto/cmp/services/accommodation/v1alpha/info.proto
+++ b/proto/cmp/services/accommodation/v1alpha/info.proto
@@ -19,7 +19,7 @@ message AccommodationProductInfoRequest {
   repeated cmp.types.v1alpha.Language languages = 3;
 
   // Property codes
-  repeated cmp.types.v1alpha.SupplierProductCodeProductCode supplier_codes = 4;
+  repeated cmp.types.v1alpha.SupplierProductCode supplier_codes = 4;
 }
 
 message AccommodationProductInfoResponse {

--- a/proto/cmp/services/accommodation/v1alpha/property_types.proto
+++ b/proto/cmp/services/accommodation/v1alpha/property_types.proto
@@ -27,7 +27,7 @@ message Property {
   google.protobuf.Timestamp last_modified = 1;
 
   // Ex: "AESPMI1234"
-  cmp.types.v1alpha.SupplierProductCode supplier_codes = 2;
+  cmp.types.v1alpha.SupplierProductCode supplier_code = 2;
 
   // Product code which can be of different types
   repeated cmp.types.v1alpha.ProductCode product_code = 3;

--- a/proto/cmp/services/accommodation/v1alpha/property_types.proto
+++ b/proto/cmp/services/accommodation/v1alpha/property_types.proto
@@ -14,6 +14,7 @@ import "cmp/types/v1alpha/phone.proto";
 import "cmp/types/v1alpha/service_fact.proto";
 import "cmp/types/v1alpha/traveller.proto";
 import "google/protobuf/timestamp.proto";
+import "cmp/types/v1alpha/product_code.proto";
 
 // ### Property message type
 //
@@ -26,48 +27,45 @@ message Property {
   google.protobuf.Timestamp last_modified = 1;
 
   // Ex: "AESPMI1234"
-  string property_code = 2;
+  cmp.types.v1alpha.SupplierProductCodeProductCode supplier_codes = 2;
+
+  // Product code which can be of different types
+  repeated cmp.types.v1alpha.ProductCode product_code = 3;
 
   // Ex: "Beach Hotel Alanya"
-  string name = 3;
+  string name = 4;
 
   // Ex: "Hilton"
-  string chain = 4;
+  string chain = 5;
 
   // Ex: CategoryRating.CATEGORY_RATING_4_5
-  CategoryRating category_rating = 5;
+  CategoryRating category_rating = 6;
 
   // Ex: CategoryUnit.CATEGORY_UNIT_PALMS
-  CategoryUnit category_unit = 6;
+  CategoryUnit category_unit = 7;
 
   // Ex: Address type
-  cmp.types.v1alpha.Address address = 7;
+  cmp.types.v1alpha.Address address = 8;
 
   // Emails
-  repeated cmp.types.v1alpha.Email emails = 8;
+  repeated cmp.types.v1alpha.Email emails = 9;
 
   // Phones
-  repeated cmp.types.v1alpha.Phone phones = 9;
+  repeated cmp.types.v1alpha.Phone phones = 10;
 
   // Location coordinate
-  cmp.types.v1alpha.Coordinate coordinate = 10;
+  cmp.types.v1alpha.Coordinate coordinate = 11;
 
   // Ex: "www.hotel.com"
-  string website = 11;
+  string website = 12;
 
   // Status of the property
   // FIXME: Changed "deactivated" to "status". But we should still make this an enum. ??
-  string status = 12;
-
-  // GIATA ID
-  string giata_id = 13;
-
-  // Goal ID
-  int32 goal_id = 14;
+  string status = 13;
 
   // Airports
   // Ex: ["PMI", "ZRH", "AYT"]
-  repeated string airports = 15;
+  repeated string airports = 14;
 }
 
 enum CategoryRating {

--- a/proto/cmp/services/accommodation/v1alpha/property_types.proto
+++ b/proto/cmp/services/accommodation/v1alpha/property_types.proto
@@ -136,28 +136,42 @@ enum PropertyStatus {
 }
 
 message Room {
-  string code = 1;
-  string name = 2;
-  repeated cmp.types.v1alpha.Image images = 3;
-  repeated cmp.types.v1alpha.Video videos = 4;
+  // Room code of the unit in case of hotel. Ex: "RMSDDB0000". For holiday homes
+  // often no room codes are used.
+  string supplier_room_code = 1;
+
+   // Room name. In case of hotel a standardized room name is often derrived from
+   // room code structures. Fo holiday homes we expect names like "Master Bedroom",
+   // "Second Bedroom" or "Bathroom" when specific descriptions for each room are
+   // available.
+  string supplier_room_name = 2;
+
+  // Original room name as assigned by the hotel. In case of spefifically designated room
+  // names by chains and both the chain and the customer wants to adhere to them.
+  // Ex: "CEIBA CLUB", "CEIBA GOVERNORS SUITE", "GOVERNORS SUITE" or "ENCLAVE NATURE VIEW"
+  // For holiday homes specific room names if availbale can be given.
+  string original_room_name =3;
+
+  repeated cmp.types.v1alpha.Image images = 4;
+  repeated cmp.types.v1alpha.Video videos = 5;
 
   // Room descriptions
-  repeated cmp.types.v1alpha.LocalizedDescriptionSet descriptions = 5;
+  repeated cmp.types.v1alpha.LocalizedDescriptionSet descriptions = 6;
 
   // Meal plan (Board code)
-  repeated cmp.types.v1alpha.MealPlan meal_plan = 6;
+  repeated cmp.types.v1alpha.MealPlan meal_plan = 7;
 
   // Beds
-  repeated cmp.types.v1alpha.Bed beds = 7;
+  repeated cmp.types.v1alpha.Bed beds = 8;
 
   // Occupancy
-  Occupancy total_occupancy = 8;
+  Occupancy total_occupancy = 9;
 
   // Services
-  repeated cmp.types.v1alpha.ServiceFact services = 9;
+  repeated cmp.types.v1alpha.ServiceFact services = 10;
 
   // Amenities
-  repeated cmp.types.v1alpha.Amenity amenities = 10;
+  repeated cmp.types.v1alpha.Amenity amenities = 11;
 }
 
 message Occupancy {

--- a/proto/cmp/services/accommodation/v1alpha/property_types.proto
+++ b/proto/cmp/services/accommodation/v1alpha/property_types.proto
@@ -61,7 +61,7 @@ message Property {
 
   // Status of the property
   // FIXME: Changed "deactivated" to "status". But we should still make this an enum. ??
-  Status status = 13;
+  PropertyStatus status = 13;
 
   // Airports
   // Ex: ["PMI", "ZRH", "AYT"]
@@ -96,13 +96,6 @@ enum CategoryUnit {
   CATEGORY_UNIT_UNSPECIFIED = 0;
   CATEGORY_UNIT_STARS = 1;
   CATEGORY_UNIT_PALMS = 2;
-}
-
-enum Status {
-  STATUS_UNSPECIFIED = 0;
-  STATUS_DRAFT = 1;
-  STATUS_ACTIVE = 2;
-  STATUS_DEACTIVATED = 3;
 }
 
 // This message type contains extended info about a property

--- a/proto/cmp/services/accommodation/v1alpha/property_types.proto
+++ b/proto/cmp/services/accommodation/v1alpha/property_types.proto
@@ -137,13 +137,16 @@ enum PropertyStatus {
 
 message Room {
   // Room code of the unit in case of hotel. Ex: "RMSDDB0000". For holiday homes
-  // often no room codes are used.
+  // often no room codes are used. This code must explicitly match the supplier_room_code
+  // in the ProductList and the ProductInfo messages, so that the static data like room
+  // amenities, descriptions, images etc. can be married to the dynamic price and
+  // availability data for display to the end user.
   string supplier_room_code = 1;
 
    // Room name. In case of hotel a standardized room name is often derrived from
-   // room code structures. Fo holiday homes we expect names like "Master Bedroom",
-   // "Second Bedroom" or "Bathroom" when specific descriptions for each room are
-   // available.
+   // room code structures. Exmple: "superior seaview room".
+   // For holiday homes we expect names like "Master Bedroom", "Second Bedroom" or
+   // "Bathroom" when specific descriptions for each room are available.
   string supplier_room_name = 2;
 
   // Original room name as assigned by the hotel. In case of spefifically designated room

--- a/proto/cmp/services/accommodation/v1alpha/property_types.proto
+++ b/proto/cmp/services/accommodation/v1alpha/property_types.proto
@@ -60,8 +60,7 @@ message Property {
   string website = 12;
 
   // Status of the property
-  // FIXME: Changed "deactivated" to "status". But we should still make this an enum. ??
-  PropertyStatus status = 13;
+    PropertyStatus status = 13;
 
   // Airports
   // Ex: ["PMI", "ZRH", "AYT"]
@@ -98,6 +97,13 @@ enum CategoryUnit {
   CATEGORY_UNIT_PALMS = 2;
 }
 
+enum PropertyStatus {
+  PROPERTY_STATUS_UNSPECIFIED = 0;
+  PROPERTY_STATUS_DRAFT = 1;
+  PROPERTY_STATUS_CONFIRMED = 2;
+  PROPERTY_STATUS_EXPIRED = 3;
+}
+
 // This message type contains extended info about a property
 message PropertyExtendedInfo {
   // Property
@@ -121,18 +127,8 @@ message PropertyExtendedInfo {
   // Payment type. Ex: "MERCHANT"
   string payment_type = 7;
 
-  // Status
-  PropertyStatus status = 8;
-
   // Rooms
-  repeated Room rooms = 9;
-}
-
-enum PropertyStatus {
-  PROPERTY_STATUS_UNSPECIFIED = 0;
-  PROPERTY_STATUS_DRAFT = 1;
-  PROPERTY_STATUS_CONFIRMED = 2;
-  PROPERTY_STATUS_EXPIRED = 3;
+  repeated Room rooms = 8;
 }
 
 message Room {

--- a/proto/cmp/services/accommodation/v1alpha/property_types.proto
+++ b/proto/cmp/services/accommodation/v1alpha/property_types.proto
@@ -27,7 +27,7 @@ message Property {
   google.protobuf.Timestamp last_modified = 1;
 
   // Ex: "AESPMI1234"
-  cmp.types.v1alpha.SupplierProductCodeProductCode supplier_codes = 2;
+  cmp.types.v1alpha.SupplierProductCode supplier_codes = 2;
 
   // Product code which can be of different types
   repeated cmp.types.v1alpha.ProductCode product_code = 3;
@@ -61,7 +61,7 @@ message Property {
 
   // Status of the property
   // FIXME: Changed "deactivated" to "status". But we should still make this an enum. ??
-  string status = 13;
+  Status status = 13;
 
   // Airports
   // Ex: ["PMI", "ZRH", "AYT"]
@@ -96,6 +96,13 @@ enum CategoryUnit {
   CATEGORY_UNIT_UNSPECIFIED = 0;
   CATEGORY_UNIT_STARS = 1;
   CATEGORY_UNIT_PALMS = 2;
+}
+
+enum Status {
+  CATEGORY_UNIT_UNSPECIFIED = 0;
+  DRAFT = 1;
+  ACTIVE = 2;
+  DEACTIVATED = 3;
 }
 
 // This message type contains extended info about a property

--- a/proto/cmp/services/accommodation/v1alpha/property_types.proto
+++ b/proto/cmp/services/accommodation/v1alpha/property_types.proto
@@ -100,9 +100,9 @@ enum CategoryUnit {
 
 enum Status {
   STATUS_UNSPECIFIED = 0;
-  DRAFT = 1;
-  ACTIVE = 2;
-  DEACTIVATED = 3;
+  STATUS_DRAFT = 1;
+  STATUS_ACTIVE = 2;
+  STATUS_DEACTIVATED = 3;
 }
 
 // This message type contains extended info about a property

--- a/proto/cmp/services/accommodation/v1alpha/property_types.proto
+++ b/proto/cmp/services/accommodation/v1alpha/property_types.proto
@@ -99,7 +99,7 @@ enum CategoryUnit {
 }
 
 enum Status {
-  CATEGORY_UNIT_UNSPECIFIED = 0;
+  STATUS_UNSPECIFIED = 0;
   DRAFT = 1;
   ACTIVE = 2;
   DEACTIVATED = 3;

--- a/proto/cmp/services/accommodation/v1alpha/search.proto
+++ b/proto/cmp/services/accommodation/v1alpha/search.proto
@@ -21,21 +21,56 @@ import "cmp/types/v1alpha/search.proto";
 // accommodations like hotel and holiday home searches within the platform. In the
 // request the market, language and currency are specified at the top-level.
 //
-// In the Unit we specify the details of the trip like dates, properties or
+// In "queries"" we specify the details of the trip like dates, properties or
 // locations or filters. The purpose of such a structure is to allow for multi-room
-// and multi-property searches. This means that there is no grouping of different
+// and multi-property search requests. 
+//
+// For the response this means that there is no grouping of different
 // room, mealplan or rateplan options in single room or single property searches.
-// Each AccommodationSearchResult is one bookable option.
+// Each AccommodationSearchResult is one bookable option as a "result_id".
 //
-// Several rooms or houses can be requested for the same dates and location or for
-// the purpose of a tour or roadtrip, several accommodations or properties for
-// sequential dates and different locations. This is done by specifying multiple
-// Units for the same or different periods, the same or different accommodations or
-// properties, specifying which travellers sleep in which unit.
+// Simple example:
+// a search for 1 room for 2 adults would be just 1 query, with one travel period and
+// one set of search parameters. The response has one query_id with many result_ids
+// for various rooms, mealplans and rateplans in one hotel and depending on the search
+// parameters, again for other hotels. Each property+room+rateplan+mealplan is one 
+// result_id with just one unit.
 //
-// Developers leveraging this message type should ensure proper validation and
-// handling, especially considering fields that are still under review, like
-// `speech_request`.
+// The simple example is also applicable for holiday homes where one or multiple
+// result_ids will be returned for various homes matching the query. The results will
+// probably not include a mealplan and in general no room information as all rooms in
+// the home are included. Flexible and non-refundable as well as packaging rateplans
+// are already surfacing in some distribution channels.
+//
+// Multi room example:
+// a search for 1 room for 2 adults in one query and another room for two adults and a
+// child of 8 in another room in the same hotel or destination for the same dates in
+// another query in the search request. This will lead to a search response with just
+// one unit for eavery possible option available for each query_id, with many result_ids.
+//
+// The same concept is valid for multiple homes for more than one family travelling
+// together to one park or destination.
+//
+// Road-trip or circuit example:
+// a search for one or multiple rooms or homes in queries that have sequential dates
+// and destinations. For example a trip to Las Vegas, a flight to New York and decending
+// the atlantic coastline to New Orleans or Orlando by car with stops in various places.
+//
+// The hostel, convention or groups example:
+// Often just 5 rooms for 10 peopleare requested or specific bed combinations like 5
+// single-use rooms (for 5 travellers) and 5 double rooms (10 travellers) are requested.
+// In this case the number of rooms is specified and the total amount of travellers,
+// but no distribution of travellers per room is detailed in the request. The reponse
+// then hold multiple units for one search_id and result_id, so that if 5 rooms are
+// requested, but only 2 standard rooms are available, the requested amount can be 
+// completed with a different room type (superior, seaview,..)
+//
+// In general, the number of available rooms should be considered to ensure that for
+// requests with multiple rooms or homes, the same room or home is not offered twice
+// to different travellers.
+//
+//
+
 message AccommodationSearchRequest {
   // Message header. Contains API version, message info string and end-user wallet
   // address
@@ -46,6 +81,9 @@ message AccommodationSearchRequest {
 
   // Generic search parameters Ex: Inclusion of OnRequest options and inclusion of
   // only the cheapest or all options.
+  // In the search parameters multiple filters can be applied for upfront filtering
+  // of the search results to for example to only include hotels that are less than
+  // one kilometer from the beach, have a kids club and offer an a la carte restaurant
   cmp.types.v1alpha.SearchParameters search_parameters_generic = 3;
 
   // This field represents a list of search queries that can be used to create

--- a/proto/cmp/services/accommodation/v1alpha/search.proto
+++ b/proto/cmp/services/accommodation/v1alpha/search.proto
@@ -21,7 +21,7 @@ import "cmp/types/v1alpha/search.proto";
 // accommodations like hotel and holiday home searches within the platform. In the
 // request the market, language and currency are specified at the top-level.
 //
-// In "queries"" we specify the details of the trip like dates, properties or
+// In "queries" we specify the details of the trip like dates, properties or
 // locations or filters. The purpose of such a structure is to allow for multi-room
 // and multi-property search requests. 
 //

--- a/proto/cmp/services/accommodation/v1alpha/search_parameters_types.proto
+++ b/proto/cmp/services/accommodation/v1alpha/search_parameters_types.proto
@@ -45,6 +45,9 @@ message AccommodationSearchParameters {
   repeated cmp.types.v1alpha.RateRule rate_rules = 8;
 
   // Product code list
-  // Here a list of property codes would be used
+  // Here a list of property codes would be used that could be of different types
   repeated cmp.types.v1alpha.ProductCode product_codes = 9;
+
+  // Or a list of provider codes would be used
+  repeated cmp.types.v1alpha.SupplierProductCode supplier_codes = 10;
 }

--- a/proto/cmp/services/accommodation/v1alpha/unit_types.proto
+++ b/proto/cmp/services/accommodation/v1alpha/unit_types.proto
@@ -25,7 +25,10 @@ message Unit {
   // Ex: `UnitType.UNIT_TYPE_ROOM`
   UnitType type = 1;
 
-  // Room code of the unit in case of hotel. Ex: "RMSDDB0000"
+  // Room code of the unit in case of hotel. Ex: "RMSDDB0000". This code must explicitly
+  // match the supplier_room_code in the ProductList and the ProductInfo messages, so that
+  // the static data like room amenities, descriptions, images etc. can be married to the
+  // dynamic price and availability data for display to the end user.
   string supplier_room_code = 2;
 
   // Room name. In case of enrichment additional name of the unit code.

--- a/proto/cmp/services/accommodation/v1alpha/unit_types.proto
+++ b/proto/cmp/services/accommodation/v1alpha/unit_types.proto
@@ -54,7 +54,7 @@ message Unit {
   // Price in detail with breakdowns
   cmp.types.v1alpha.PriceDetail price_detail = 8;
 
-  // Services
+  // Included, compulsory and optional services available
   repeated cmp.types.v1alpha.ServiceFact services = 9;
 
   // Mealplan code
@@ -72,13 +72,13 @@ message Unit {
   // arrival z€
   repeated cmp.types.v1alpha.CancelPolicy cancel_policies = 13;
 
-  // Remaining units
+  // Number of remaining units at the time of calculation
   int32 remaining_units = 14;
 
   // Property code which can be of different types
   cmp.types.v1alpha.ProductCode property_code = 15;
  
-  // Property code
+  // Supplier Property code, consistent in ProductList, ProductInfo and Search
   cmp.types.v1alpha.SupplierProductCode supplier_code = 16;
 
   // Remarks

--- a/proto/cmp/services/accommodation/v1alpha/unit_types.proto
+++ b/proto/cmp/services/accommodation/v1alpha/unit_types.proto
@@ -25,56 +25,63 @@ message Unit {
   // Ex: `UnitType.UNIT_TYPE_ROOM`
   UnitType type = 1;
 
-  // Unit code. Room code of the unit in case of hotel. Ex: "RMSDDB0000"
-  string unit_code = 2;
+  // Room code of the unit in case of hotel. Ex: "RMSDDB0000"
+  string supplier_room_code = 2;
 
-  // Unit name. In case of enrichment additional name of the unit code.
-  // Ex: "Double Standard Room"
-  string unit_name = 3;
+  // Room name. In case of enrichment additional name of the unit code.
+  // In theory, this field should never be included as it is already available in
+  // the static data. However, some providers prefer to be specific to avoid room
+  // mapping issues. Ex: "Double Standard Room"
+  string supplier_room_name = 3;
+
+  // Original room name as assigned by the hotel. In case of spefifically designated room
+  // names by chains and both the chain and the customer wants to adhere to them.
+  // Ex: "CEIBA CLUB", "CEIBA GOVERNORS SUITE", "GOVERNORS SUITE" or "ENCLAVE NATURE VIEW"
+  string original_room_name = 4;
 
   // Travel period
-  cmp.types.v1alpha.TravelPeriod travel_period = 4;
+  cmp.types.v1alpha.TravelPeriod travel_period = 5;
 
   // Travellers
-  repeated cmp.types.v1alpha.Traveller travellers = 5;
+  repeated cmp.types.v1alpha.Traveller travellers = 6;
 
   // Beds
-  repeated cmp.types.v1alpha.Bed beds = 6;
+  repeated cmp.types.v1alpha.Bed beds = 7;
 
   // Price in detail with breakdowns
-  cmp.types.v1alpha.PriceDetail price_detail = 7;
+  cmp.types.v1alpha.PriceDetail price_detail = 8;
 
   // Services
-  repeated cmp.types.v1alpha.ServiceFact services = 8;
+  repeated cmp.types.v1alpha.ServiceFact services = 9;
 
   // Mealplan code
-  cmp.types.v1alpha.MealPlan meal_plan_code = 9;
+  cmp.types.v1alpha.MealPlan meal_plan_code = 10;
 
   // Rate plan
-  cmp.types.v1alpha.RatePlan rate_plan = 10;
+  cmp.types.v1alpha.RatePlan rate_plan = 11;
 
   // Rate Rule
-  cmp.types.v1alpha.RateRule rate_rule = 11;
+  cmp.types.v1alpha.RateRule rate_rule = 12;
 
   // This is a list so that various policies can be expressed.
   //
   // Ex: 10-5 days before arrival x€, 4-1 days before arrival y€ and 0 days before
   // arrival z€
-  repeated cmp.types.v1alpha.CancelPolicy cancel_policies = 12;
+  repeated cmp.types.v1alpha.CancelPolicy cancel_policies = 13;
 
   // Remaining units
-  int32 remaining_units = 13;
+  int32 remaining_units = 14;
 
   // Property code which can be of different types
-  cmp.types.v1alpha.ProductCode property_code = 14;
+  cmp.types.v1alpha.ProductCode property_code = 15;
  
   // Property code
-  cmp.types.v1alpha.SupplierProductCode supplier_code = 15;
+  cmp.types.v1alpha.SupplierProductCode supplier_code = 16;
 
   // Remarks
   // Non structural aspects related to the unit a supplier wants to include in the search
   // response
-  string remarks = 16;
+  string remarks = 17;
 }
 
 enum UnitType {

--- a/proto/cmp/services/accommodation/v1alpha/unit_types.proto
+++ b/proto/cmp/services/accommodation/v1alpha/unit_types.proto
@@ -65,12 +65,16 @@ message Unit {
   // Remaining units
   int32 remaining_units = 13;
 
-  // Property code
+  // Property code which can be of different types
   cmp.types.v1alpha.ProductCode property_code = 14;
+ 
+  // Property code
+  cmp.types.v1alpha.SupplierProductCode supplier_code = 15;
 
   // Remarks
-  // FIXME: Is this field "per Unit" or should it be "per search request"?
-  string remarks = 15;
+  // Non structural aspects related to the unit a supplier wants to include in the search
+  // response
+  string remarks = 16;
 }
 
 enum UnitType {

--- a/proto/cmp/services/activity/v1alpha/list.proto
+++ b/proto/cmp/services/activity/v1alpha/list.proto
@@ -5,7 +5,6 @@ package cmp.services.activity.v1alpha;
 import "cmp/services/activity/v1alpha/search_result_types.proto";
 import "cmp/types/v1alpha/common.proto";
 import "google/protobuf/timestamp.proto";
-import "cmp/types/v1alpha/product_code.proto";
 
 message ActivityProductListRequest {
   // Message header

--- a/proto/cmp/services/activity/v1alpha/list.proto
+++ b/proto/cmp/services/activity/v1alpha/list.proto
@@ -5,6 +5,7 @@ package cmp.services.activity.v1alpha;
 import "cmp/services/activity/v1alpha/search_result_types.proto";
 import "cmp/types/v1alpha/common.proto";
 import "google/protobuf/timestamp.proto";
+import "cmp/types/v1alpha/product_code.proto";
 
 message ActivityProductListRequest {
   // Message header

--- a/proto/cmp/services/activity/v1alpha/search_parameters_types.proto
+++ b/proto/cmp/services/activity/v1alpha/search_parameters_types.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package cmp.services.activity.v1alpha;
 
 import "cmp/types/v1alpha/language.proto";
-import "cmp/types/v1alpha/time.proto";
+import "cmp/types/v1alpha/duration.proto";
 import "cmp/types/v1alpha/price.proto";
 import "cmp/types/v1alpha/product_code.proto";
 
@@ -61,8 +61,8 @@ message ActivitySearchParameters {
   //
   // Specify the minimal and maximum duration of an activity to be included in the
   // search response
-  cmp.types.v1alpha.Time min_duration = 8;
-  cmp.types.v1alpha.Time max_duration = 9;
+  cmp.types.v1alpha.Duration min_duration = 8;
+  cmp.types.v1alpha.Duration max_duration = 9;
 
   // Pricerange
   //

--- a/proto/cmp/services/activity/v1alpha/search_parameters_types.proto
+++ b/proto/cmp/services/activity/v1alpha/search_parameters_types.proto
@@ -20,45 +20,54 @@ message ActivitySearchParameters {
   repeated cmp.types.v1alpha.Language spoken_language = 1;
 
   // Specify one or more product codes to be included in the search response
-  //
+  // These can be of different types
   // Ex: "TC000000"
   repeated cmp.types.v1alpha.ProductCode product_codes = 2;
 
+  // Specify one or more supplier codes to be included in the search response
+  // These must match the supplier codes provided in the ProductList and
+  // ProductInfo messages
+  repeated cmp.types.v1alpha.SupplierProductCode supplier_codes = 3;
+
   // Specify one or more activity IDs to be included in the search response
-  //
+  // The purpose of this concept is to allow for different activities for one product
+  // like "Windsurfing" and "Kitesurfing" under "Salou Playa Llarga".
+  // Code and description match the information provided in the ProductList and 
+  // ProductInfo message. These are in general also supplier specific.
   // Ex: "EESPMI46VY"
-  repeated string activity_id = 3;
+  repeated string activity_id = 4;
 
   // Specify one or more service codes to be included in the search response
-  //
+  // Several different packages could be included like "Windsurfing" with or without
+  // "Wetsuit". Code and description match the information provided in the ProductInfo message
+  // These are in general also supplier specific
   // Ex: "XO"
-  repeated string service_code = 4;
+  repeated string service_code = 5;
 
   // Specify one or more category codes to be included in the search response
-  //
-  // Ex: "XA"
-  repeated string category_code = 5;
+  // This concept is covering classification and segmentation aspects like for example
+  // Museum tours, Outdoor activities, Theme parks etc...
+  // Code and description match the information provided in the ProductInfo message
+  // These are in general also supplier specific
+    repeated string category_code = 6;
 
   // Specify one or more type codes to be included in the search response
-  //
-  // Ex: "SF"
-  repeated string type_code = 6;
+  // A code to identify a specific type of excursion like Leisure, Activity, Learning, etc
+  // Code and description match the information provided in the ProductInfo message
+  // These are in general also supplier specific
+  repeated string type_code = 7;
 
   // Duration
   //
   // Specify the minimal and maximum duration of an activity to be included in the
   // search response
-  cmp.types.v1alpha.Time min_duration = 7;
-  cmp.types.v1alpha.Time max_duration = 8;
+  cmp.types.v1alpha.Time min_duration = 8;
+  cmp.types.v1alpha.Time max_duration = 9;
 
   // Pricerange
   //
   // Specify the minimum and maximum price of an activity to be included in the
   // search response
-  cmp.types.v1alpha.Price min_price = 9;
-  cmp.types.v1alpha.Price max_price = 10;
-
-  // Specify one or more brand codes or distribution channels for which assigned
-  // product is to be included in the search response
-  repeated string brand_code = 11;
+  cmp.types.v1alpha.Price min_price = 10;
+  cmp.types.v1alpha.Price max_price = 11;
 }

--- a/proto/cmp/services/activity/v1alpha/search_result_types.proto
+++ b/proto/cmp/services/activity/v1alpha/search_result_types.proto
@@ -7,6 +7,7 @@ import "cmp/types/v1alpha/datetime_range.proto";
 import "cmp/types/v1alpha/location.proto";
 import "cmp/types/v1alpha/price.proto";
 import "google/protobuf/timestamp.proto";
+import "cmp/types/v1alpha/product_code.proto";
 
 // This type represents a search result and is used in the `ActivitySearchResponse`
 // message.
@@ -46,43 +47,46 @@ message ActivitySearchResult {
 
 // Represents an Activity product.
 //
-// FIXME: We need optimizations in this type
+// See extensive explanations in search_parameters_types
 message Activity {
   // Ex: "TC000000"
-  string product_code = 1;
+  cmp.types.v1alpha.SupplierProductCodeProductCode supplier_codes = 1;
+
+  // Product code which can be of different types
+  cmp.types.v1alpha.ProductCode product_code = 2;
 
   // Ex: "Helicopter Tour Heli"
-  string product_name = 2;
+  string product_name = 3;
 
   // Ex: "EESPMI46VY"
-  string activity_id = 3;
+  string activity_id = 4;
 
   // Ex: "Tour (40 min)"
-  string activity_name = 4;
+  string activity_name = 5;
 
   // Ex: "XO"
-  string service_code = 5;
+  string service_code = 6;
 
   // Ex: "with transfer from/to hotel"
-  string service_name = 6;
+  string service_name = 7;
 
   // Ex: "XA"
-  string category_code = 7;
+  string category_code = 8;
 
   // Ex: "Excursions & Activities"
-  string category_name = 8;
+  string category_name = 9;
 
   // Ex: "SF"
-  string type_code = 9;
+  string type_code = 10;
 
   // Ex: "Safari"
-  string type_name = 10;
+  string type_name = 11;
 
   // Status
   //
   // FIXME: We need to make this an ENUM (this is also used for several other
   // verticals)
-  string status = 11;
+  string status = 12;
 }
 
 // ### Activity Location

--- a/proto/cmp/services/activity/v1alpha/search_result_types.proto
+++ b/proto/cmp/services/activity/v1alpha/search_result_types.proto
@@ -50,7 +50,7 @@ message ActivitySearchResult {
 // See extensive explanations in search_parameters_types
 message Activity {
   // Ex: "TC000000"
-  cmp.types.v1alpha.SupplierProductCodeProductCode supplier_codes = 1;
+  cmp.types.v1alpha.SupplierProductCode supplier_codes = 1;
 
   // Product code which can be of different types
   cmp.types.v1alpha.ProductCode product_code = 2;

--- a/proto/cmp/services/activity/v1alpha/search_result_types.proto
+++ b/proto/cmp/services/activity/v1alpha/search_result_types.proto
@@ -50,7 +50,7 @@ message ActivitySearchResult {
 // See extensive explanations in search_parameters_types
 message Activity {
   // Ex: "TC000000"
-  cmp.types.v1alpha.SupplierProductCode supplier_codes = 1;
+  cmp.types.v1alpha.SupplierProductCode supplier_code = 1;
 
   // Product code which can be of different types
   cmp.types.v1alpha.ProductCode product_code = 2;

--- a/proto/cmp/services/transport/v1alpha/search_parameters_types.proto
+++ b/proto/cmp/services/transport/v1alpha/search_parameters_types.proto
@@ -5,6 +5,7 @@ package cmp.services.transport.v1alpha;
 import "cmp/types/v1alpha/price.proto";
 import "cmp/types/v1alpha/product_code.proto";
 import "cmp/types/v1alpha/time.proto";
+import "cmp/types/v1alpha/duration.proto";
 
 // ### Transport Search Parameters
 //
@@ -21,10 +22,10 @@ message TransportSearchParameters {
   repeated cmp.types.v1alpha.SupplierProductCode supplier_code_codes = 2;
 
   // The minimum duration of a transport to be included in the search response
-  cmp.types.v1alpha.Time min_duration = 3;
+  cmp.types.v1alpha.Duration min_duration = 3;
 
   // The maximum duration of a transport to be included in the search response
-  cmp.types.v1alpha.Time max_duration = 4;
+  cmp.types.v1alpha.Duration max_duration = 4;
 
   // The minimum price of a transport to be included in the search response
   cmp.types.v1alpha.Price min_price = 5;

--- a/proto/cmp/services/transport/v1alpha/search_parameters_types.proto
+++ b/proto/cmp/services/transport/v1alpha/search_parameters_types.proto
@@ -12,39 +12,44 @@ import "cmp/types/v1alpha/time.proto";
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1alpha/search_parameters_types.proto.dot.svg)
 message TransportSearchParameters {
   // Specify one or more type codes to be included in the search response
-  // Ex: "SF"
+  // Ex: code "EW" number "1234" of the type "IATA"
   repeated cmp.types.v1alpha.ProductCode product_codes = 1;
 
+  // Specify one or more supplier codes to be included in the search response
+  // These must match the supplier codes provided in the ProductList and
+  // ProductInfo messages
+  repeated cmp.types.v1alpha.SupplierProductCode supplier_code_codes = 2;
+
   // The minimum duration of a transport to be included in the search response
-  cmp.types.v1alpha.Time min_duration = 2;
+  cmp.types.v1alpha.Time min_duration = 3;
 
   // The maximum duration of a transport to be included in the search response
-  cmp.types.v1alpha.Time max_duration = 3;
+  cmp.types.v1alpha.Time max_duration = 4;
 
   // The minimum price of a transport to be included in the search response
-  cmp.types.v1alpha.Price min_price = 4;
+  cmp.types.v1alpha.Price min_price = 5;
 
   // The maximum price of a transport to be included in the search response
-  cmp.types.v1alpha.Price max_price = 5;
+  cmp.types.v1alpha.Price max_price = 6;
 
   // One or more brand codes or distribution channels for which assigned product is
   // to be included in the search response
-  repeated string brand_code = 6;
+  repeated string brand_code = 7;
 
   // The maximum number of segments a trip might be containing, if only a direct
   // flight, transfer, or train journey the maximum number of segments is set to
   // one.
-  int32 max_segments = 7;
+  int32 max_segments = 8;
 
   // Minimum departure time of the trip
-  cmp.types.v1alpha.Time trip_min_departure_time = 8;
+  cmp.types.v1alpha.Time trip_min_departure_time = 9;
 
   // Maximum departure time of the trip
-  cmp.types.v1alpha.Time trip_max_departure_time = 9;
+  cmp.types.v1alpha.Time trip_max_departure_time = 10;
 
   // Minimum arrival time of the trip
-  cmp.types.v1alpha.Time trip_min_arrival_time = 10;
+  cmp.types.v1alpha.Time trip_min_arrival_time = 11;
 
   // Maximum arrival time of the trip
-  cmp.types.v1alpha.Time trip_max_arrival_time = 11;
+  cmp.types.v1alpha.Time trip_max_arrival_time = 12;
 }

--- a/proto/cmp/services/transport/v1alpha/trip_types.proto
+++ b/proto/cmp/services/transport/v1alpha/trip_types.proto
@@ -50,13 +50,13 @@ message TripSegment {
   // Similar "interline" or "code share" operation may exist in rail and transfer.
   string retailer_code = 3;
 
-  // Sub Provider Code, replacing Operating carrier or identifying sub contracted
+  // Sub supplier code, replacing Operating carrier or identifying sub contracted
   // services provided by other suppliers.
   //
   // DB could be selling an intenational train trip operated by the Dutch Nederlands
   // Spoorwegen (NS) or the French SNCF. Holiday Taxis could be selling a transfer
   // that is operated by Transunion.
-  string sub_provider_code = 4;
+  string sub_supplier_code = 4;
 
   // Product Code and Number
   //
@@ -69,12 +69,15 @@ message TripSegment {
   // Transfers are often identified by just a product code servicing an area.
   cmp.types.v1alpha.ProductCode product_code = 5;
   
+  // Supplier specific code, matching the supplier code in ProductList and ProductInfo
+  // messages
+  cmp.types.v1alpha.SupplierProductCode supplier_code = 6;
 
   // Departure
-  TransitEvent departure = 6;
+  TransitEvent departure = 7;
 
   // Arrival
-  TransitEvent arrival = 7;
+  TransitEvent arrival = 8;
 
   // Flights, trains and transfers often offer different service types
   // for a product. Think about economy or business for flights, first and second
@@ -84,41 +87,41 @@ message TripSegment {
   // flight: "Y", "J", "F".
   // train: "1st", "2nd" or "S", "C", "P"
   // transfer: "S", "P", "VIP", "SS"
-  string service_type_code = 8;
+  string service_type_code = 9;
 
   // Service type description examples:
   // flight: "Economy Class", "Business Class", "First Class"
   // train: "First Class", "Second Class" or "standard", "comfort", and "premium",..
   // transfer: "Shuttle", "Private", "VIP Limosine", "Speedy Shuttle",...
-  string service_type_description = 9;
+  string service_type_description = 10;
 
   // Trip Time
   //
   // Ex: Time(hours=2, minutes=45)
-  cmp.types.v1alpha.Time trip_time = 10;
+  cmp.types.v1alpha.Time trip_time = 11;
 
   // Trip Distance
   //
   // Ex: `Length(value=15, unit=LengthUnit.DISTANCE_UNIT_KILOMETERS)`
-  cmp.types.v1alpha.Length trip_distance = 11;
+  cmp.types.v1alpha.Length trip_distance = 12;
 
   // Min PAX
   //
   // Ex: `1`
-  int32 min_pax = 12;
+  int32 min_pax = 13;
 
   // Max PAX
   //
   // Ex: `3`
-  int32 max_pax = 13;
+  int32 max_pax = 14;
 
   // Luggage
   //
   // Ex: `3`
-  cmp.types.v1alpha.Baggage baggage = 14;
+  cmp.types.v1alpha.Baggage baggage = 15;
 
   // Price
   //
   // Ex: `Price(net=240, currency=Currency.CURRENCY_EUR)
-  cmp.types.v1alpha.Price price = 15;
+  cmp.types.v1alpha.Price price = 16;
 }

--- a/proto/cmp/services/transport/v1alpha/trip_types.proto
+++ b/proto/cmp/services/transport/v1alpha/trip_types.proto
@@ -98,7 +98,7 @@ message TripSegment {
   // Trip Time
   //
   // Ex: Time(hours=2, minutes=45)
-  cmp.types.v1alpha.Time trip_time = 11;
+  cmp.types.v1alpha.Time trip_duration = 11;
 
   // Trip Distance
   //

--- a/proto/cmp/services/transport/v1alpha/trip_types.proto
+++ b/proto/cmp/services/transport/v1alpha/trip_types.proto
@@ -95,9 +95,7 @@ message TripSegment {
   // transfer: "Shuttle", "Private", "VIP Limosine", "Speedy Shuttle",...
   string service_type_description = 10;
 
-  // Trip Time
-  //
-  // Ex: Time(hours=2, minutes=45)
+  // Trip duration in minutes
   cmp.types.v1alpha.Duration trip_duration = 11;
 
   // Trip Distance

--- a/proto/cmp/services/transport/v1alpha/trip_types.proto
+++ b/proto/cmp/services/transport/v1alpha/trip_types.proto
@@ -6,7 +6,7 @@ import "cmp/types/v1alpha/baggage.proto";
 import "cmp/types/v1alpha/location.proto";
 import "cmp/types/v1alpha/measurement.proto";
 import "cmp/types/v1alpha/price.proto";
-import "cmp/types/v1alpha/time.proto";
+import "cmp/types/v1alpha/duration.proto";
 import "cmp/types/v1alpha/product_code.proto";
 import "google/protobuf/timestamp.proto";
 
@@ -98,7 +98,7 @@ message TripSegment {
   // Trip Time
   //
   // Ex: Time(hours=2, minutes=45)
-  cmp.types.v1alpha.Time trip_duration = 11;
+  cmp.types.v1alpha.Duration trip_duration = 11;
 
   // Trip Distance
   //

--- a/proto/cmp/types/v1alpha/duration.proto
+++ b/proto/cmp/types/v1alpha/duration.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package cmp.types.v1alpha;
+
+// Time Message
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1alpha/duration.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1alpha/duration.proto.dot.svg)
+message Duration {
+  int32 minutes = 1;
+}

--- a/proto/cmp/types/v1alpha/filter.proto
+++ b/proto/cmp/types/v1alpha/filter.proto
@@ -20,6 +20,10 @@ message Filter {
   // implementation provider specific which undermines the "connect once, connect to
   // many" replication idea
   //
+  // Conclusively we recommend to filter using standards. It is much better to filter
+  // for seaview or seaside rooms using for example DRV global types supported by many
+  // providers of the Camino Nnetwork, than to implement specific logics per provider, 
+  // using their unique codes
   string filter_code = 1;
 
   // Description of the filter code.

--- a/proto/cmp/types/v1alpha/product_code.proto
+++ b/proto/cmp/types/v1alpha/product_code.proto
@@ -34,7 +34,7 @@ enum ProductCodeType {
 
 message SupplierProductCode {
 
-  // The supplier product code is unique for a product provider by the supplier and it 
+  // The supplier product code is unique for a product provided by the supplier and it 
   // must remain consistent across the different messages like the ProductList, ProductInfo
   // and Search messages. Mapping is done on static data, however making a search request
   // with a GiataID or an ICAO code, could return one or more search results with each

--- a/proto/cmp/types/v1alpha/product_code.proto
+++ b/proto/cmp/types/v1alpha/product_code.proto
@@ -12,10 +12,12 @@ message ProductCode {
 
   // In most cases like in accommodation, just the field "code" and "type" will be
   // used. For example in case of a GiataID (for example code=182568), a provider
-  // hotel code (for example MTS hotel code=AESPMI1234), a transfer code, etc.
+  // hotel code (for example a hotel code=AESPMI1234), a transfer code, etc.
   // However, for flight and train it is common to have a code and a number like "EW
   // 51" or "ICE 2803", which would then be code=EW and number=51 or code=ICE and
-  // number=2803
+  // number=2803. It is not recommended to concatenate for example the airline code
+  // and the flight number into the code field as "EW 51", as this would cause different
+  // implementations for providers of the same product.
   string code = 1;
   int32 number = 2;
   ProductCodeType type = 3;
@@ -24,9 +26,27 @@ message ProductCode {
 // Product Code type
 enum ProductCodeType {
   PRODUCT_CODE_TYPE_UNSPECIFIED = 0;
-  PRODUCT_CODE_TYPE_PROVIDER = 1;
-  PRODUCT_CODE_TYPE_GIATA = 2;
-  PRODUCT_CODE_TYPE_GOAL_ID = 3;
-  PRODUCT_CODE_TYPE_IATA = 4;
-  PRODUCT_CODE_TYPE_ICAO = 5;
+  PRODUCT_CODE_TYPE_GIATA = 1;
+  PRODUCT_CODE_TYPE_GOAL_ID = 2;
+  PRODUCT_CODE_TYPE_IATA = 3;
+  PRODUCT_CODE_TYPE_ICAO = 4;
 }
+
+message SupplierProductCode {
+
+  // The supplier product code is unique for a product provider by the supplier and it 
+  // must remain consistent across the different messages like the ProductList, ProductInfo
+  // and Search messages. Mapping is done on static data, however making a search request
+  // with a GiataID or an ICAO code, could return one or more search results with each
+  // individual supplier codes in case the code type is not unique and the supplier has
+  // multiple products for the requested code. An example could be making a request for an
+  // accommodation with a GiataID and the supplier can offer a product with just the hotel,
+  // the hotel with a ski pass or the hotel with a rent a car. For packages we can imagine
+  // an accommodation, the accommodation with a flight and transfer or the accommodation with
+  // a flight and a rent a car. As the product descriptions from the supplier will have
+  // different services, it is safe to assume the product codes will be differnt, the product
+  // name will be different and the descriptions and amenities as well in the ProductList and 
+  // ProductInfo messages.
+  string supplier_code = 1;
+  int32 supplier_number = 2;
+  }

--- a/proto/cmp/types/v1alpha/search.proto
+++ b/proto/cmp/types/v1alpha/search.proto
@@ -51,12 +51,11 @@ message SearchParameters {
 
   // Free-text field to provide more detials for better offer personalization. This
   // field can be provided in combination with a Geo location or as stand-alone.
-  string search_description_text = 10;
-
-  // The speech is provided as a link to a recording to process for better offer
-  // personalization. This field can be provided in combination with a Geo location
+  // If speech is provided as a recording for better offer personalization, then
+  // the recording has to be processed to text.
+  // This field can be provided in combination with a Geo location
   // or as stand-alone.
-  string search_description_audio_url = 11;
+  string search_description_text = 10;
 
   // Content source types for this search request to specify which sources to
   // include.
@@ -64,7 +63,7 @@ message SearchParameters {
   // Ex: ContentSourceType.CONTENT_SOURCE_TYPE_GDS,
   // ContentSourceType.CONTENT_SOURCE_TYPE_NDC
   // ContentSourceType.CONTENT_SOURCE_TYPE_3RD_PARTY
-  repeated ContentSourceType content_source_types = 12;
+  repeated ContentSourceType content_source_types = 11;
 }
 
 // This message type is used in every search request to contain the request metadata

--- a/proto/cmp/types/v1alpha/search.proto
+++ b/proto/cmp/types/v1alpha/search.proto
@@ -26,31 +26,34 @@ message SearchParameters {
   // Request generated for a specific market according to ISO 3166-1 Country codes
   Country market = 3;
 
+  // Request generated for a specific brand or point-of-sale by one distributor
+  Brand brand = 4;
+
   // Include OnRequest options in the response or only immediately bookable options
-  bool include_on_request = 4;
+  bool include_on_request = 5;
 
   // Only show the cheapest option for one product, or include all possible
   // combinations
-  bool include_combinations = 5;
+  bool include_combinations = 6;
 
   // Limit the maximum number of options included in the response
-  int32 max_options = 6;
+  int32 max_options = 7;
 
   // Specify the sorting required in the response
-  Sorting sorting = 7;
+  Sorting sorting = 8;
 
   // Filters for the search. Various provider and product specific filters can be
   // provided here in agreed name/value pairs.
-  repeated Filter filters = 8;
+  repeated Filter filters = 9;
 
   // Free-text field to provide more detials for better offer personalization. This
   // field can be provided in combination with a Geo location or as stand-alone.
-  string search_description_text = 9;
+  string search_description_text = 10;
 
   // The speech is provided as a link to a recording to process for better offer
   // personalization. This field can be provided in combination with a Geo location
   // or as stand-alone.
-  string search_description_audio_url = 10;
+  string search_description_audio_url = 11;
 
   // Content source types for this search request to specify which sources to
   // include.
@@ -58,7 +61,7 @@ message SearchParameters {
   // Ex: ContentSourceType.CONTENT_SOURCE_TYPE_GDS,
   // ContentSourceType.CONTENT_SOURCE_TYPE_NDC
   // ContentSourceType.CONTENT_SOURCE_TYPE_3RD_PARTY
-  repeated ContentSourceType content_source_types = 11;
+  repeated ContentSourceType content_source_types = 12;
 }
 
 // This message type is used in every search request to contain the request metadata

--- a/proto/cmp/types/v1alpha/search.proto
+++ b/proto/cmp/types/v1alpha/search.proto
@@ -9,7 +9,6 @@ import "cmp/types/v1alpha/filter.proto";
 import "cmp/types/v1alpha/language.proto";
 import "cmp/types/v1alpha/sorting.proto";
 import "cmp/types/v1alpha/uuid.proto";
-import "cmp/types/v1alpha/product_code.proto";
 
 // Search parameters for the search requests
 //

--- a/proto/cmp/types/v1alpha/search.proto
+++ b/proto/cmp/types/v1alpha/search.proto
@@ -9,6 +9,7 @@ import "cmp/types/v1alpha/filter.proto";
 import "cmp/types/v1alpha/language.proto";
 import "cmp/types/v1alpha/sorting.proto";
 import "cmp/types/v1alpha/uuid.proto";
+import "cmp/types/v1alpha/product_code.proto";
 
 // Search parameters for the search requests
 //
@@ -27,7 +28,9 @@ message SearchParameters {
   Country market = 3;
 
   // Request generated for a specific brand or point-of-sale by one distributor
-  Brand brand = 4;
+  // Specify one or more brand codes or distribution channels for which assigned
+  // product is to be included in the search response
+  repeated string brand_code = 4;
 
   // Include OnRequest options in the response or only immediately bookable options
   bool include_on_request = 5;

--- a/proto/cmp/types/v1alpha/service_fact.proto
+++ b/proto/cmp/types/v1alpha/service_fact.proto
@@ -5,6 +5,17 @@ package cmp.types.v1alpha;
 import "cmp/types/v1alpha/price.proto";
 
 // Service fact message type
+// Service facts are smaller services that are included, can be booked optionally
+// or must be booked together with a main product or service. For example on Christmas
+// eve a gala dinner is included in the stay. Or an early check-in can be booked when
+// travellers have an early flight. Or cleaning cost must be included for every booking
+// of a holiday home.
+//
+// It is important that these optional, included or compulsary services are simple. For
+// complex combinations like a hotel with a rent-a-car or a skipass or ski lessons, packages
+// should be used so that each service can be described properly and a choice of what car,
+// which ski pass and what level of ski class that be properly selected.
+//
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1alpha/service_fact.proto.dot.xs.svg)
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1alpha/service_fact.proto.dot.svg)


### PR DESCRIPTION
Implementation of review comments from partners including:

ProductList, ProductInfo and SearchResponse for Accommodation message types, renaming unit_code to supplier_room_code and adding original_room_name.

Explain the requirement for a unique code between ProductList, ProductInfo and SearchResponse to be able to map static and dynamic data correctly. Better explain unit for property, room, mealplan, rateplan logic for multi room/property. Improve documentation of Servicefacts. Adding "Brand" in search.proto (field order changed).