### PR TITLE
Split Request and Response Headers

### DIFF
--- a/proto/cmp/services/accommodation/v1alpha/info.proto
+++ b/proto/cmp/services/accommodation/v1alpha/info.proto
@@ -10,7 +10,7 @@ import "google/protobuf/timestamp.proto";
 
 message AccommodationProductInfoRequest {
   // Message header
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.RequestHeader header = 1;
 
   // Only respond with the products that are modified after this timestamp
   google.protobuf.Timestamp modified_after = 2;
@@ -24,7 +24,7 @@ message AccommodationProductInfoRequest {
 
 message AccommodationProductInfoResponse {
   // Message header
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.ResponseHeader header = 1;
 
   // Product list: Properties
   repeated PropertyExtendedInfo properties = 2;

--- a/proto/cmp/services/accommodation/v1alpha/list.proto
+++ b/proto/cmp/services/accommodation/v1alpha/list.proto
@@ -8,7 +8,7 @@ import "google/protobuf/timestamp.proto";
 
 message AccommodationProductListRequest {
   // Message header
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.RequestHeader header = 1;
 
   // Only respond with the products that are modified after this timestamp
   google.protobuf.Timestamp modified_after = 2;
@@ -16,7 +16,7 @@ message AccommodationProductListRequest {
 
 message AccommodationProductListResponse {
   // Message header
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.ResponseHeader header = 1;
 
   // Product list: Properties
   repeated Property properties = 2;

--- a/proto/cmp/services/accommodation/v1alpha/search.proto
+++ b/proto/cmp/services/accommodation/v1alpha/search.proto
@@ -73,7 +73,7 @@ import "cmp/types/v1alpha/traveller.proto";
 message AccommodationSearchRequest {
   // Message header. Contains API version, message info string and end-user wallet
   // address
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.RequestHeader header = 1;
 
   // Search request metadata
   cmp.types.v1alpha.SearchRequestMetadata metadata = 2;
@@ -100,7 +100,7 @@ message AccommodationSearchRequest {
 message AccommodationSearchResponse {
   // Message header. Contains API version, message info string and end user wallet
   // address.
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.ResponseHeader header = 1;
 
   // Search response metadata
   cmp.types.v1alpha.SearchResponseMetadata metadata = 2;

--- a/proto/cmp/services/activity/v1alpha/list.proto
+++ b/proto/cmp/services/activity/v1alpha/list.proto
@@ -8,7 +8,7 @@ import "google/protobuf/timestamp.proto";
 
 message ActivityProductListRequest {
   // Message header
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.RequestHeader header = 1;
 
   // Only respond with the products that are modified after this timestamp
   google.protobuf.Timestamp modified_after = 2;
@@ -16,7 +16,7 @@ message ActivityProductListRequest {
 
 message ActivityProductListResponse {
   // Message header
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.ResponseHeader header = 1;
 
   // Product list: Activities
   repeated Activity activities = 2;

--- a/proto/cmp/services/activity/v1alpha/search.proto
+++ b/proto/cmp/services/activity/v1alpha/search.proto
@@ -25,7 +25,7 @@ import "cmp/types/v1alpha/traveller.proto";
 message ActivitySearchRequest {
   // Message header. Contains API version, message info string and end-user wallet
   // address
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.RequestHeader header = 1;
 
   // Search request metadata
   cmp.types.v1alpha.SearchRequestMetadata metadata = 2;
@@ -103,7 +103,7 @@ message ActivitySearchRequest {
 message ActivitySearchResponse {
   // Message header. Contains API version, message info string and end user wallet
   // address.
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.ResponseHeader header = 1;
 
   // Search response metadata
   cmp.types.v1alpha.SearchResponseMetadata metadata = 2;

--- a/proto/cmp/services/book/v1alpha/mint.proto
+++ b/proto/cmp/services/book/v1alpha/mint.proto
@@ -12,7 +12,7 @@ import "google/protobuf/timestamp.proto";
 
 message MintRequest {
   // Message header
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.RequestHeader header = 1;
 
   string validation_id = 2;
 
@@ -40,7 +40,7 @@ message MintRequest {
 
 message MintResponse {
   // Message header
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.ResponseHeader header = 1;
 
   // This must be a UUID according to RFC 4122
   string mint_id = 2;

--- a/proto/cmp/services/book/v1alpha/validate.proto
+++ b/proto/cmp/services/book/v1alpha/validate.proto
@@ -7,7 +7,7 @@ import "cmp/types/v1alpha/price.proto";
 
 message ValidationRequest {
   // Message header
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.RequestHeader header = 1;
 
   // Search ID that is returned in the search response message in the `metadata``
   // (`SearchResponseMetadata`) field.
@@ -20,7 +20,7 @@ message ValidationRequest {
 
 message ValidationResponse {
   // Message header
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.ResponseHeader header = 1;
 
   // Unique validation ID. This must be a UUID according to RFC 4122
   string validation_id = 2;

--- a/proto/cmp/services/ping/v1alpha/ping.proto
+++ b/proto/cmp/services/ping/v1alpha/ping.proto
@@ -11,7 +11,7 @@ import "google/protobuf/timestamp.proto";
 // stored of each hop.
 message PingRequest {
   // Message Header
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.RequestHeader header = 1;
 
   // Ping message
   string ping_message = 2;
@@ -22,7 +22,7 @@ message PingRequest {
 
 message PingResponse {
   // Message Header
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.ResponseHeader header = 1;
 
   // Ping message
   string ping_message = 2;

--- a/proto/cmp/services/transport/v1alpha/search.proto
+++ b/proto/cmp/services/transport/v1alpha/search.proto
@@ -22,7 +22,7 @@ import "cmp/types/v1alpha/traveller.proto";
 message TransportSearchRequest {
   // Message header. Contains API version, message info string and end-user wallet
   // address
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.RequestHeader header = 1;
 
   // Search request metadata
   cmp.types.v1alpha.SearchRequestMetadata metadata = 2;
@@ -43,7 +43,7 @@ message TransportSearchRequest {
 message TransportSearchResponse {
   // Message header. Contains API version, message info string and end-user wallet
   // address
-  cmp.types.v1alpha.Header header = 1;
+  cmp.types.v1alpha.ResponseHeader header = 1;
 
   // Search response metadata
   cmp.types.v1alpha.SearchResponseMetadata metadata = 2;

--- a/proto/cmp/types/v1alpha/common.proto
+++ b/proto/cmp/types/v1alpha/common.proto
@@ -62,3 +62,35 @@ message Version {
   // versioning)
   int32 patch = 3;
 }
+
+message RequestHeader {
+  Header base_header = 1;
+}
+
+message ResponseHeader {
+  Header base_header = 1;
+
+  // Status of the response, success or failure
+  StatusType status = 2;
+
+  // Alert for more detailed information about the response
+  repeated Alert alerts = 3;
+}
+
+message Alert {
+  string message = 1;
+  AlertType type = 2;
+}
+
+enum AlertType {
+  ALERT_TYPE_UNSPECIFIED = 0;
+  ALERT_TYPE_INFO = 1;
+  ALERT_TYPE_WARNING = 2;
+  ALERT_TYPE_ERROR = 3;
+}
+
+enum StatusType {
+  STATUS_TYPE_UNSPECIFIED = 0;
+  STATUS_TYPE_SUCCESS = 1;
+  STATUS_TYPE_FAILURE = 2;
+}


### PR DESCRIPTION
This PR splits the `header` messages for requests and responses. It's based on `validate-mint` branch (#16). So, needs to be merged after that PR. 