### PR TITLE
Fix repeated directives and Localized fields

### DIFF
--- a/proto/cmp/services/info/v1alpha/entry_requirements.proto
+++ b/proto/cmp/services/info/v1alpha/entry_requirements.proto
@@ -77,7 +77,7 @@ message CountryEntryRequirementCategory {
   repeated cmp.types.v1alpha.LocalizedString names = 2;
 
   // Items
-  CountryEntryRequirementItem items = 3;
+  repeated CountryEntryRequirementItem items = 3;
 
   // Sub categories
   repeated CountryEntryRequirementCategory sub_categories = 4;

--- a/proto/cmp/services/seat_map/v1alpha/seat_map.proto
+++ b/proto/cmp/services/seat_map/v1alpha/seat_map.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package cmp.services.seat_map.v1alpha;
-
+import "cmp/types/v1alpha/language.proto";
 import "cmp/types/v1alpha/common.proto";
 import "cmp/types/v1alpha/seat_map.proto";
 
@@ -19,6 +19,9 @@ message SeatMapRequest {
   // This is the map ID that is received in the search results and also from the
   // product info responses.
   string map_id = 2;
+
+  // Languages
+  repeated cmp.types.v1alpha.Language languages = 3;
 }
 
 // Response for seat map request

--- a/proto/cmp/services/seat_map/v1alpha/seat_map.proto
+++ b/proto/cmp/services/seat_map/v1alpha/seat_map.proto
@@ -20,7 +20,7 @@ message SeatMapRequest {
   // product info responses.
   string map_id = 2;
 
-  // Languages
+  // Requested Languages
   repeated cmp.types.v1alpha.Language languages = 3;
 }
 

--- a/proto/cmp/types/v1alpha/seat_map.proto
+++ b/proto/cmp/types/v1alpha/seat_map.proto
@@ -93,6 +93,7 @@ message SeatMap {
 
   // A list of localized descriptions for the seat map. This can be used to describe
   // features and amenities of the seating arrangement in multiple languages.
+  // The languages should match those requested in SeatMapRequest
   repeated cmp.types.v1alpha.LocalizedDescriptionSet localized_descriptions = 4;
 }
 

--- a/proto/cmp/types/v1alpha/seat_map.proto
+++ b/proto/cmp/types/v1alpha/seat_map.proto
@@ -20,10 +20,10 @@ message Seat {
   SeatLocation location = 2;
 
   // Static features associated with the seat, such as type, amenities, etc.
-  repeated SeatAttribute features = 3;
+  repeated LocalizedSeatAttributeSet features = 3;
 
   // Restrictions associated with the seat, such as age limits or accessibility requirements.
-  repeated SeatAttribute restrictions = 4;
+  repeated LocalizedSeatAttributeSet restrictions = 4;
 }
 
 // List of seats

--- a/proto/cmp/types/v1alpha/seat_map.proto
+++ b/proto/cmp/types/v1alpha/seat_map.proto
@@ -6,6 +6,7 @@ import "cmp/types/v1alpha/description.proto";
 import "cmp/types/v1alpha/file.proto";
 import "google/protobuf/wrappers.proto";
 import "cmp/types/v1alpha/language.proto";
+import "cmp/types/v1alpha/localized.proto";
 // Represents a basic seat with optional features and restrictions. Each seat has a
 // unique identifier, a location within the seat map, and can have various static
 // features and restrictions associated with it.
@@ -40,8 +41,8 @@ message Section {
   // "Orchestra" or "A", "12". Must be unique for each section.
   string id = 1;
 
-  // Human readable name of the section
-  string name = 2;
+  // List of localized names Human readable names of the section
+  repeated cmp.types.v1alpha.LocalizedString names = 2;
 
   // Seats in this section.
   oneof seat_info {

--- a/proto/cmp/types/v1alpha/seat_map.proto
+++ b/proto/cmp/types/v1alpha/seat_map.proto
@@ -5,7 +5,7 @@ package cmp.types.v1alpha;
 import "cmp/types/v1alpha/description.proto";
 import "cmp/types/v1alpha/file.proto";
 import "google/protobuf/wrappers.proto";
-
+import "cmp/types/v1alpha/language.proto";
 // Represents a basic seat with optional features and restrictions. Each seat has a
 // unique identifier, a location within the seat map, and can have various static
 // features and restrictions associated with it.
@@ -141,6 +141,12 @@ message SeatMapInventory {
   repeated SectionInventory sections = 2;
 }
 
+message LocalizedSeatAttributeSet {
+
+  Language language = 1;
+  repeated SeatAttribute seat_attributes = 2;
+
+}
 /* Helper messages */
 
 // Defines a static attribute for a seat, which can be used for specifying features

--- a/proto/cmp/types/v1alpha/seat_map.proto
+++ b/proto/cmp/types/v1alpha/seat_map.proto
@@ -60,9 +60,9 @@ message Section {
   // used to represent seat location inside this image).
   cmp.types.v1alpha.Image image = 5;
 
-  // A set of localized descriptions for this section, useful for providing
+  // A list of localized descriptions for this section, useful for providing
   // information about features and amenities in multiple languages.
-  cmp.types.v1alpha.LocalizedDescriptionSet localized_description_set = 6;
+  repeated cmp.types.v1alpha.LocalizedDescriptionSet localized_descriptions = 6;
 
   // Nested sections within this section, allowing for a hierarchical representation
   // of the venue's layout.
@@ -90,9 +90,9 @@ message SeatMap {
   // bitmap format.
   cmp.types.v1alpha.Image image = 3;
 
-  // A set of localized descriptions for the seat map. This can be used to describe
+  // A list of localized descriptions for the seat map. This can be used to describe
   // features and amenities of the seating arrangement in multiple languages.
-  cmp.types.v1alpha.LocalizedDescriptionSet localized_description_set = 4;
+  repeated cmp.types.v1alpha.LocalizedDescriptionSet localized_descriptions = 4;
 }
 
 // List of _only_ seat IDs to be used for seat selection or seat availability.


### PR DESCRIPTION
[#628](https://github.com/chain4travel/camino-private-issues/issues/628)
- [x] `LocalizedDescriptionSet` renamed to `LocalizedDescriptions`
Multilingual:
- [x] Added in the `SeatMapRequest` a repeated `language` field
- [x] In the response made `LocalizedDescriptions` a repeated field **(to cater for all languages requested*)**
- [x] `CountryEntryRequirementCategory`, the `Items` made a repeated field  
Localized descriptions
- [x] `SeatAttribute`, group `name` and `destription` into a new message and add the language so that we can insert it in `SeatAttribute` with a repeated -> made it like LocalizedDescriptionSet, where language is not part of the message but a part of set
- [x] For section` name`  used existing `LocalizedString` type

\* should bot or "final system" filter the languages for the response? 