### PR TITLE
Migrate buf config to version 2

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,16 +1,17 @@
-version: v1
+version: v2
 managed:
   enabled: true
-  go_package_prefix:
-    default: buf.build/chain4travel/camino-messenger-protocol
+  override:
+    - file_option: go_package_prefix
+      value: buf.build/chain4travel/camino-messenger-protocol
 plugins:
-  - plugin: buf.build/protocolbuffers/go
+  - remote: buf.build/protocolbuffers/go
     out: gen/go
     opt: paths=source_relative
-  - plugin: buf.build/bufbuild/connect-go
+  - remote: buf.build/bufbuild/connect-go
     out: gen/go
     opt: paths=source_relative
-  - plugin: buf.build/community/danielgtaylor-betterproto:v1.2.5
+  - remote: buf.build/community/danielgtaylor-betterproto:v1.2.5
     out: gen/python
-  - plugin: buf.build/protocolbuffers/python:v25.1
+  - remote: buf.build/protocolbuffers/python:v25.1
     out: gen/pbpy

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,11 @@
+version: v2
+modules:
+  - path: proto
+    name: buf.build/chain4travel/camino-messenger-protocol
+lint:
+  use:
+    - STANDARD
+breaking:
+  use:
+    - FILE
+  ignore_unstable_packages: true

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,9 +1,0 @@
-version: v1
-name: buf.build/chain4travel/camino-messenger-protocol
-breaking:
-  ignore_unstable_packages: true
-  use:
-    - FILE
-lint:
-  use:
-    - DEFAULT


### PR DESCRIPTION
This migrates the buf's config version to v2.

> [!WARNING]
> You may need to update your buf cli tool to latest version