### PR TITLE
Fix v2 diagram links

### DIFF
--- a/proto/cmp/services/accommodation/v1/info.proto
+++ b/proto/cmp/services/accommodation/v1/info.proto
@@ -33,6 +33,7 @@ message AccommodationProductInfoResponse {
 // Accommodation product info service definition
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/info.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/info.proto.dot.svg)
 service AccommodationProductInfoService {
   // Returns product list for accommodation (properties)

--- a/proto/cmp/services/accommodation/v1/list.proto
+++ b/proto/cmp/services/accommodation/v1/list.proto
@@ -25,6 +25,7 @@ message AccommodationProductListResponse {
 // Accommodation product list service definition
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/list.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/list.proto.dot.svg)
 service AccommodationProductListService {
   // Returns product list for accommodation (properties)

--- a/proto/cmp/services/accommodation/v1/property_types.proto
+++ b/proto/cmp/services/accommodation/v1/property_types.proto
@@ -18,6 +18,7 @@ import "google/protobuf/timestamp.proto";
 // Represents property info for an accommodation product
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/property_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/property_types.proto.dot.svg)
 message Property {
   // Ex: "2023-08-28T12:03:50", specifying when the static data of a product was

--- a/proto/cmp/services/accommodation/v1/search.proto
+++ b/proto/cmp/services/accommodation/v1/search.proto
@@ -115,6 +115,7 @@ message AccommodationSearchResponse {
 // Service definition for Accommodation search
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/search.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/search.proto.dot.svg)
 service AccommodationSearchService {
   // Accommodation Search method

--- a/proto/cmp/services/accommodation/v1/search_parameters_types.proto
+++ b/proto/cmp/services/accommodation/v1/search_parameters_types.proto
@@ -11,6 +11,7 @@ import "cmp/types/v1/rate.proto";
 // codes etc.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/search_parameters_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/search_parameters_types.proto.dot.svg)
 message AccommodationSearchParameters {
   // Geo Location for search, set only one of the fields at once.

--- a/proto/cmp/services/accommodation/v1/search_result_types.proto
+++ b/proto/cmp/services/accommodation/v1/search_result_types.proto
@@ -12,6 +12,7 @@ import "cmp/types/v1/rate.proto";
 // `AccommodationSearchResponse` message.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/search_result_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/search_result_types.proto.dot.svg)
 message AccommodationSearchResult {
   // ID for the search result. This is an increasing number starting at 0 and

--- a/proto/cmp/services/accommodation/v1/unit_types.proto
+++ b/proto/cmp/services/accommodation/v1/unit_types.proto
@@ -18,6 +18,7 @@ import "cmp/types/v1/travel_period.proto";
 // homes. Ex: 1 house for 4 persons and another house for 6 persons.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/unit_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/unit_types.proto.dot.svg)
 message Unit {
   // Unit Type. Used to distinguish between hotel rooms and holiday homes.

--- a/proto/cmp/services/accommodation/v2/info.proto
+++ b/proto/cmp/services/accommodation/v2/info.proto
@@ -32,8 +32,8 @@ message AccommodationProductInfoResponse {
 
 // Accommodation product info service definition
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/info.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/info.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/info.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/info.proto.dot.svg)
 service AccommodationProductInfoService {
   // Returns product list for accommodation (properties)
   rpc AccommodationProductInfo(AccommodationProductInfoRequest) returns (AccommodationProductInfoResponse);

--- a/proto/cmp/services/accommodation/v2/info.proto
+++ b/proto/cmp/services/accommodation/v2/info.proto
@@ -33,6 +33,7 @@ message AccommodationProductInfoResponse {
 // Accommodation product info service definition
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/info.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/info.proto.dot.svg)
 service AccommodationProductInfoService {
   // Returns product list for accommodation (properties)

--- a/proto/cmp/services/accommodation/v2/list.proto
+++ b/proto/cmp/services/accommodation/v2/list.proto
@@ -25,6 +25,7 @@ message AccommodationProductListResponse {
 // Accommodation product list service definition
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/list.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/list.proto.dot.svg)
 service AccommodationProductListService {
   // Returns product list for accommodation (properties)

--- a/proto/cmp/services/accommodation/v2/list.proto
+++ b/proto/cmp/services/accommodation/v2/list.proto
@@ -24,8 +24,8 @@ message AccommodationProductListResponse {
 
 // Accommodation product list service definition
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/list.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/list.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/list.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/list.proto.dot.svg)
 service AccommodationProductListService {
   // Returns product list for accommodation (properties)
   rpc AccommodationProductList(AccommodationProductListRequest) returns (AccommodationProductListResponse);

--- a/proto/cmp/services/accommodation/v2/property_types.proto
+++ b/proto/cmp/services/accommodation/v2/property_types.proto
@@ -18,6 +18,7 @@ import "google/protobuf/timestamp.proto";
 // Represents property info for an accommodation product
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/property_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/property_types.proto.dot.svg)
 message Property {
   // Ex: "2023-08-28T12:03:50", specifying when the static data of a product was

--- a/proto/cmp/services/accommodation/v2/property_types.proto
+++ b/proto/cmp/services/accommodation/v2/property_types.proto
@@ -17,8 +17,8 @@ import "google/protobuf/timestamp.proto";
 
 // Represents property info for an accommodation product
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/property_types.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/property_types.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/property_types.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/property_types.proto.dot.svg)
 message Property {
   // Ex: "2023-08-28T12:03:50", specifying when the static data of a product was
   // last updated

--- a/proto/cmp/services/accommodation/v2/search.proto
+++ b/proto/cmp/services/accommodation/v2/search.proto
@@ -114,8 +114,8 @@ message AccommodationSearchResponse {
 
 // Service definition for Accommodation search
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/search.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/search.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search.proto.dot.svg)
 service AccommodationSearchService {
   // Accommodation Search method
   rpc AccommodationSearch(AccommodationSearchRequest) returns (AccommodationSearchResponse);

--- a/proto/cmp/services/accommodation/v2/search.proto
+++ b/proto/cmp/services/accommodation/v2/search.proto
@@ -115,6 +115,7 @@ message AccommodationSearchResponse {
 // Service definition for Accommodation search
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search.proto.dot.svg)
 service AccommodationSearchService {
   // Accommodation Search method

--- a/proto/cmp/services/accommodation/v2/search_parameters_types.proto
+++ b/proto/cmp/services/accommodation/v2/search_parameters_types.proto
@@ -11,6 +11,7 @@ import "cmp/types/v2/product_code.proto";
 // codes etc.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search_parameters_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search_parameters_types.proto.dot.svg)
 message AccommodationSearchParameters {
   // Geo Location for search, set only one of the fields at once.

--- a/proto/cmp/services/accommodation/v2/search_parameters_types.proto
+++ b/proto/cmp/services/accommodation/v2/search_parameters_types.proto
@@ -10,8 +10,8 @@ import "cmp/types/v2/product_code.proto";
 // This type is used in search requests for parameters like location, meal plan
 // codes etc.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/search_parameters_types.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/search_parameters_types.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search_parameters_types.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search_parameters_types.proto.dot.svg)
 message AccommodationSearchParameters {
   // Geo Location for search, set only one of the fields at once.
   //

--- a/proto/cmp/services/accommodation/v2/search_result_types.proto
+++ b/proto/cmp/services/accommodation/v2/search_result_types.proto
@@ -12,6 +12,7 @@ import "cmp/types/v2/price.proto";
 // `AccommodationSearchResponse` message.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search_result_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search_result_types.proto.dot.svg)
 message AccommodationSearchResult {
   // ID for the search result. This is an increasing number starting at 0 and

--- a/proto/cmp/services/accommodation/v2/search_result_types.proto
+++ b/proto/cmp/services/accommodation/v2/search_result_types.proto
@@ -11,8 +11,8 @@ import "cmp/types/v2/price.proto";
 // This type represents a search result and is used in the
 // `AccommodationSearchResponse` message.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/search_result_types.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/search_result_types.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search_result_types.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search_result_types.proto.dot.svg)
 message AccommodationSearchResult {
   // ID for the search result. This is an increasing number starting at 0 and
   // increasing by 1 for every search result.

--- a/proto/cmp/services/accommodation/v2/unit_types.proto
+++ b/proto/cmp/services/accommodation/v2/unit_types.proto
@@ -17,8 +17,8 @@ import "cmp/types/v2/service_fact.proto";
 // A unit can also be a different property in a multi-property request for holiday
 // homes. Ex: 1 house for 4 persons and another house for 6 persons.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/unit_types.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v1/unit_types.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/unit_types.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/unit_types.proto.dot.svg)
 message Unit {
   // Unit Type. Used to distinguish between hotel rooms and holiday homes.
   // Ex: `UnitType.UNIT_TYPE_ROOM`

--- a/proto/cmp/services/accommodation/v2/unit_types.proto
+++ b/proto/cmp/services/accommodation/v2/unit_types.proto
@@ -18,6 +18,7 @@ import "cmp/types/v2/service_fact.proto";
 // homes. Ex: 1 house for 4 persons and another house for 6 persons.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/unit_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/unit_types.proto.dot.svg)
 message Unit {
   // Unit Type. Used to distinguish between hotel rooms and holiday homes.

--- a/proto/cmp/services/activity/v1/activity_types.proto
+++ b/proto/cmp/services/activity/v1/activity_types.proto
@@ -19,6 +19,7 @@ import "google/protobuf/timestamp.proto";
 // This represents Activity types which is needed for different activity services (search, info, ... etc)
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/activity_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/activity_types.proto.dot.svg)
 message Activity {
   // Context for Inventory system concepts that need to be included in an info

--- a/proto/cmp/services/activity/v1/info.proto
+++ b/proto/cmp/services/activity/v1/info.proto
@@ -35,6 +35,7 @@ message ActivityProductInfoResponse {
 // Activity product info service definition
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/info.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/info.proto.dot.svg)
 service ActivityProductInfoService {
   // Returns product list for activity

--- a/proto/cmp/services/activity/v1/list.proto
+++ b/proto/cmp/services/activity/v1/list.proto
@@ -25,6 +25,7 @@ message ActivityProductListResponse {
 // This service is used to get a product list for activities.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/list.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/list.proto.dot.svg)
 service ActivityProductListService {
   // Gets an optional `modified_after` date and returns a product list.

--- a/proto/cmp/services/activity/v1/search.proto
+++ b/proto/cmp/services/activity/v1/search.proto
@@ -152,6 +152,7 @@ message ActivitySearchResponse {
 // Takes `ActivitySearchRequest` message type and returns `ActivitySearchResponse` message type.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/search.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/search.proto.dot.svg)
 service ActivitySearchService {
   rpc ActivitySearch(ActivitySearchRequest) returns (ActivitySearchResponse);

--- a/proto/cmp/services/activity/v1/search_parameters_types.proto
+++ b/proto/cmp/services/activity/v1/search_parameters_types.proto
@@ -10,6 +10,7 @@ import "cmp/types/v1/product_code.proto";
 // These are Activity specific search parameters
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/search_parameters_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/search_parameters_types.proto.dot.svg)
 message ActivitySearchParameters {
   // Specify the language(s) a potential guide should speak for example a tour in

--- a/proto/cmp/services/activity/v1/search_result_types.proto
+++ b/proto/cmp/services/activity/v1/search_result_types.proto
@@ -11,6 +11,7 @@ import "cmp/types/v1/price_type.proto";
 // message.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/search_result_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/search_result_types.proto.dot.svg)
 message ActivitySearchResult {
   // Option ID for the search option. This is an increasing number starting at 0 and

--- a/proto/cmp/services/activity/v2/activity_types.proto
+++ b/proto/cmp/services/activity/v2/activity_types.proto
@@ -19,6 +19,7 @@ import "google/protobuf/timestamp.proto";
 // Activity
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/activity_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/activity_types.proto.dot.svg)
 message Activity {
   // Context for Inventory system concepts that need to be included in an info

--- a/proto/cmp/services/activity/v2/activity_types.proto
+++ b/proto/cmp/services/activity/v2/activity_types.proto
@@ -18,8 +18,8 @@ import "google/protobuf/timestamp.proto";
 
 // Activity
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/activity_types.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/activity_types.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/activity_types.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/activity_types.proto.dot.svg)
 message Activity {
   // Context for Inventory system concepts that need to be included in an info
   // response, like an OwnerCode, PTC_OfferParameters, Tax codes, Disclosure RefID,

--- a/proto/cmp/services/activity/v2/info.proto
+++ b/proto/cmp/services/activity/v2/info.proto
@@ -34,8 +34,8 @@ message ActivityProductInfoResponse {
 
 // Activity product info service definition
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/info.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/info.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/info.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/info.proto.dot.svg)
 service ActivityProductInfoService {
   // Returns product list for activity
   rpc ActivityProductInfo(ActivityProductInfoRequest) returns (ActivityProductInfoResponse);

--- a/proto/cmp/services/activity/v2/info.proto
+++ b/proto/cmp/services/activity/v2/info.proto
@@ -35,6 +35,7 @@ message ActivityProductInfoResponse {
 // Activity product info service definition
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/info.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/info.proto.dot.svg)
 service ActivityProductInfoService {
   // Returns product list for activity

--- a/proto/cmp/services/activity/v2/list.proto
+++ b/proto/cmp/services/activity/v2/list.proto
@@ -25,6 +25,7 @@ message ActivityProductListResponse {
 // This service is used to get a product list for activities.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/list.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/list.proto.dot.svg)
 service ActivityProductListService {
   // Gets an optional `modified_after` date and returns a product list.

--- a/proto/cmp/services/activity/v2/list.proto
+++ b/proto/cmp/services/activity/v2/list.proto
@@ -24,8 +24,8 @@ message ActivityProductListResponse {
 
 // This service is used to get a product list for activities.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/list.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/list.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/list.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/list.proto.dot.svg)
 service ActivityProductListService {
   // Gets an optional `modified_after` date and returns a product list.
   rpc ActivityProductList(ActivityProductListRequest) returns (ActivityProductListResponse);

--- a/proto/cmp/services/activity/v2/search.proto
+++ b/proto/cmp/services/activity/v2/search.proto
@@ -151,8 +151,8 @@ message ActivitySearchResponse {
 //
 // Takes `ActivitySearchRequest` message type and returns `ActivitySearchResponse` message type.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/search.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/search.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search.proto.dot.svg)
 service ActivitySearchService {
   rpc ActivitySearch(ActivitySearchRequest) returns (ActivitySearchResponse);
 }

--- a/proto/cmp/services/activity/v2/search.proto
+++ b/proto/cmp/services/activity/v2/search.proto
@@ -152,6 +152,7 @@ message ActivitySearchResponse {
 // Takes `ActivitySearchRequest` message type and returns `ActivitySearchResponse` message type.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search.proto.dot.svg)
 service ActivitySearchService {
   rpc ActivitySearch(ActivitySearchRequest) returns (ActivitySearchResponse);

--- a/proto/cmp/services/activity/v2/search_parameters_types.proto
+++ b/proto/cmp/services/activity/v2/search_parameters_types.proto
@@ -9,8 +9,8 @@ import "cmp/types/v2/product_code.proto";
 
 // These are Activity specific search parameters
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/search_parameters_types.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/search_parameters_types.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search_parameters_types.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search_parameters_types.proto.dot.svg)
 message ActivitySearchParameters {
   // Specify the language(s) a potential guide should speak for example a tour in
   // the Anne Frank house in Amsterdam in French or the tour at the pyramids in

--- a/proto/cmp/services/activity/v2/search_parameters_types.proto
+++ b/proto/cmp/services/activity/v2/search_parameters_types.proto
@@ -10,6 +10,7 @@ import "cmp/types/v2/product_code.proto";
 // These are Activity specific search parameters
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search_parameters_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search_parameters_types.proto.dot.svg)
 message ActivitySearchParameters {
   // Specify the language(s) a potential guide should speak for example a tour in

--- a/proto/cmp/services/activity/v2/search_result_types.proto
+++ b/proto/cmp/services/activity/v2/search_result_types.proto
@@ -11,6 +11,7 @@ import "cmp/types/v2/price.proto";
 // message.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search_result_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search_result_types.proto.dot.svg)
 message ActivitySearchResult {
   // Option ID for the search option. This is an increasing number starting at 0 and

--- a/proto/cmp/services/activity/v2/search_result_types.proto
+++ b/proto/cmp/services/activity/v2/search_result_types.proto
@@ -10,8 +10,8 @@ import "cmp/types/v2/price.proto";
 // This type represents a search result and is used in the `ActivitySearchResponse`
 // message.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/search_result_types.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v1/search_result_types.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search_result_types.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search_result_types.proto.dot.svg)
 message ActivitySearchResult {
   // Option ID for the search option. This is an increasing number starting at 0 and
   // increasing by 1 for every search result.

--- a/proto/cmp/services/book/v1/mint.proto
+++ b/proto/cmp/services/book/v1/mint.proto
@@ -84,6 +84,7 @@ message MintResponse {
 }
 
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v1/mint.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v1/mint.proto.dot.svg)
 service MintService {
   rpc Mint(MintRequest) returns (MintResponse);

--- a/proto/cmp/services/book/v1/validate.proto
+++ b/proto/cmp/services/book/v1/validate.proto
@@ -46,6 +46,7 @@ message ValidationObject {
 }
 
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v1/validate.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v1/validate.proto.dot.svg)
 service ValidationService {
   rpc Validation(ValidationRequest) returns (ValidationResponse);

--- a/proto/cmp/services/book/v2/mint.proto
+++ b/proto/cmp/services/book/v2/mint.proto
@@ -88,8 +88,8 @@ message MintResponse {
   string buy_transaction_id = 11;
 }
 
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v1/mint.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v1/mint.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v2/mint.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v2/mint.proto.dot.svg)
 service MintService {
   rpc Mint(MintRequest) returns (MintResponse);
 }

--- a/proto/cmp/services/book/v2/mint.proto
+++ b/proto/cmp/services/book/v2/mint.proto
@@ -89,6 +89,7 @@ message MintResponse {
 }
 
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v2/mint.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v2/mint.proto.dot.svg)
 service MintService {
   rpc Mint(MintRequest) returns (MintResponse);

--- a/proto/cmp/services/book/v2/validate.proto
+++ b/proto/cmp/services/book/v2/validate.proto
@@ -46,6 +46,7 @@ message ValidationObject {
 }
 
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v2/validate.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v2/validate.proto.dot.svg)
 service ValidationService {
   rpc Validation(ValidationRequest) returns (ValidationResponse);

--- a/proto/cmp/services/book/v2/validate.proto
+++ b/proto/cmp/services/book/v2/validate.proto
@@ -45,8 +45,8 @@ message ValidationObject {
   }
 }
 
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v1/validate.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v1/validate.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v2/validate.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v2/validate.proto.dot.svg)
 service ValidationService {
   rpc Validation(ValidationRequest) returns (ValidationResponse);
 }

--- a/proto/cmp/services/info/v1/entry_requirements.proto
+++ b/proto/cmp/services/info/v1/entry_requirements.proto
@@ -13,6 +13,7 @@ import "cmp/types/v1/uuid.proto";
 import "google/protobuf/timestamp.proto";
 
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/info/v1/entry_requirements.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/info/v1/entry_requirements.proto.dot.svg)
 service CountryEntryRequirementsService {
   rpc CountryEntryRequirements(CountryEntryRequirementsRequest) returns (CountryEntryRequirementsResponse);

--- a/proto/cmp/services/info/v2/entry_requirements.proto
+++ b/proto/cmp/services/info/v2/entry_requirements.proto
@@ -13,6 +13,7 @@ import "cmp/types/v2/country.proto";
 import "google/protobuf/timestamp.proto";
 
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/info/v2/entry_requirements.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/info/v2/entry_requirements.proto.dot.svg)
 service CountryEntryRequirementsService {
   rpc CountryEntryRequirements(CountryEntryRequirementsRequest) returns (CountryEntryRequirementsResponse);

--- a/proto/cmp/services/info/v2/entry_requirements.proto
+++ b/proto/cmp/services/info/v2/entry_requirements.proto
@@ -12,8 +12,8 @@ import "cmp/types/v1/uuid.proto";
 import "cmp/types/v2/country.proto";
 import "google/protobuf/timestamp.proto";
 
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/info/v1/entry_requirements.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/info/v1/entry_requirements.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/info/v2/entry_requirements.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/info/v2/entry_requirements.proto.dot.svg)
 service CountryEntryRequirementsService {
   rpc CountryEntryRequirements(CountryEntryRequirementsRequest) returns (CountryEntryRequirementsResponse);
 }

--- a/proto/cmp/services/insurance/v1/info.proto
+++ b/proto/cmp/services/insurance/v1/info.proto
@@ -35,6 +35,7 @@ message InsuranceProductInfoResponse {
 // Insurance product info service definition
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v1/info.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v1/info.proto.dot.svg)
 service InsuranceProductInfoService {
   // Returns product info for insurance

--- a/proto/cmp/services/insurance/v1/insurance_types.proto
+++ b/proto/cmp/services/insurance/v1/insurance_types.proto
@@ -13,6 +13,7 @@ import "google/protobuf/timestamp.proto";
 // Insurance
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v1/insurance_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v1/insurance_types.proto.dot.svg)
 message Insurance {
   // Context for Inventory system concepts that need to be included in an info

--- a/proto/cmp/services/insurance/v1/list.proto
+++ b/proto/cmp/services/insurance/v1/list.proto
@@ -25,6 +25,7 @@ message InsuranceProductListResponse {
 // This service is used to get a product list for insurances.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v1/list.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v1/list.proto.dot.svg)
 service InsuranceProductListService {
   // Gets an optional `modified_after` date and returns a product list.

--- a/proto/cmp/services/insurance/v1/search.proto
+++ b/proto/cmp/services/insurance/v1/search.proto
@@ -83,6 +83,7 @@ message InsuranceSearchResponse {
 // Service definition for Insurance search
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v1/search.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v1/search.proto.dot.svg)
 service InsuranceSearchService {
   // Insurance Search method

--- a/proto/cmp/services/insurance/v1/search_parameters_types.proto
+++ b/proto/cmp/services/insurance/v1/search_parameters_types.proto
@@ -13,6 +13,7 @@ import "cmp/types/v2/traveller.proto";
 // This type is used in search requests for parameters like insured booking, network, ... etc
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v1/search_parameters_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v1/search_parameters_types.proto.dot.svg)
 message InsuranceSearchParameters {
   // Product code list

--- a/proto/cmp/services/insurance/v1/search_result_types.proto
+++ b/proto/cmp/services/insurance/v1/search_result_types.proto
@@ -9,6 +9,7 @@ import "cmp/types/v2/price.proto";
 // `InsuranceSearchResponse` message.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v1/search_result_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v1/search_result_types.proto.dot.svg)
 message InsuranceSearchResult {
   // ID for the search result. This is an increasing number starting at 0 and

--- a/proto/cmp/services/network/v1/fee.proto
+++ b/proto/cmp/services/network/v1/fee.proto
@@ -5,6 +5,7 @@ package cmp.services.network.v1;
 // Network Fee Message Type
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/network/v1/fee.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/network/v1/fee.proto.dot.svg)
 message NetworkFee {
   // Network fee, unit is nCAM

--- a/proto/cmp/services/partner/v1/partner_configuration.proto
+++ b/proto/cmp/services/partner/v1/partner_configuration.proto
@@ -33,6 +33,7 @@ message GetPartnerConfigurationResponse {
 // Get Partner Configuration Service
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v1/partner_configuration.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v1/partner_configuration.proto.dot.svg)
 service GetPartnerConfigurationService {
   // #### GetPartnerConfiguration

--- a/proto/cmp/services/partner/v2/partner_configuration.proto
+++ b/proto/cmp/services/partner/v2/partner_configuration.proto
@@ -32,8 +32,8 @@ message GetPartnerConfigurationResponse {
 
 // Get Partner Configuration Service
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v1/partner_configuration.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v1/partner_configuration.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v2/partner_configuration.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v2/partner_configuration.proto.dot.svg)
 service GetPartnerConfigurationService {
   // #### GetPartnerConfiguration
   //

--- a/proto/cmp/services/partner/v2/partner_configuration.proto
+++ b/proto/cmp/services/partner/v2/partner_configuration.proto
@@ -33,6 +33,7 @@ message GetPartnerConfigurationResponse {
 // Get Partner Configuration Service
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v2/partner_configuration.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v2/partner_configuration.proto.dot.svg)
 service GetPartnerConfigurationService {
   // #### GetPartnerConfiguration

--- a/proto/cmp/services/ping/v1/ping.proto
+++ b/proto/cmp/services/ping/v1/ping.proto
@@ -34,6 +34,7 @@ message PingResponse {
 // The Ping Service definition
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/ping/v1/ping.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/ping/v1/ping.proto.dot.svg)
 service PingService {
   // Ping Method

--- a/proto/cmp/services/seat_map/v1/availability.proto
+++ b/proto/cmp/services/seat_map/v1/availability.proto
@@ -50,6 +50,7 @@ message SeatMapAvailabilityResponse {
 // Service is used to request the seat map availability data for a given map ID
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v1/availability.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v1/availability.proto.dot.svg)
 service SeatMapAvailabilityService {
   // Get seat map availability data

--- a/proto/cmp/services/seat_map/v1/seat_map.proto
+++ b/proto/cmp/services/seat_map/v1/seat_map.proto
@@ -43,6 +43,7 @@ message SeatMapResponse {
 // Service for requesting seat map data for a given map ID
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v1/seat_map.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v1/seat_map.proto.dot.svg)
 service SeatMapService {
   // Get seat map data

--- a/proto/cmp/services/seat_map/v2/availability.proto
+++ b/proto/cmp/services/seat_map/v2/availability.proto
@@ -50,6 +50,7 @@ message SeatMapAvailabilityResponse {
 // Service is used to request the seat map availability data for a given map ID
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v2/availability.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v2/availability.proto.dot.svg)
 service SeatMapAvailabilityService {
   // Get seat map availability data

--- a/proto/cmp/services/seat_map/v2/availability.proto
+++ b/proto/cmp/services/seat_map/v2/availability.proto
@@ -49,8 +49,8 @@ message SeatMapAvailabilityResponse {
 //
 // Service is used to request the seat map availability data for a given map ID
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v1/availability.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v1/availability.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v2/availability.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v2/availability.proto.dot.svg)
 service SeatMapAvailabilityService {
   // Get seat map availability data
   //

--- a/proto/cmp/services/seat_map/v2/seat_map.proto
+++ b/proto/cmp/services/seat_map/v2/seat_map.proto
@@ -42,8 +42,8 @@ message SeatMapResponse {
 
 // Service for requesting seat map data for a given map ID
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v1/seat_map.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v1/seat_map.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v2/seat_map.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v2/seat_map.proto.dot.svg)
 service SeatMapService {
   // Get seat map data
   //

--- a/proto/cmp/services/seat_map/v2/seat_map.proto
+++ b/proto/cmp/services/seat_map/v2/seat_map.proto
@@ -43,6 +43,7 @@ message SeatMapResponse {
 // Service for requesting seat map data for a given map ID
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v2/seat_map.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v2/seat_map.proto.dot.svg)
 service SeatMapService {
   // Get seat map data

--- a/proto/cmp/services/transport/v1/search.proto
+++ b/proto/cmp/services/transport/v1/search.proto
@@ -68,6 +68,7 @@ message TransportSearchResponse {
 // message type.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/search.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/search.proto.dot.svg)
 service TransportSearchService {
   rpc TransportSearch(TransportSearchRequest) returns (TransportSearchResponse);

--- a/proto/cmp/services/transport/v1/search_parameters_types.proto
+++ b/proto/cmp/services/transport/v1/search_parameters_types.proto
@@ -10,6 +10,7 @@ import "cmp/types/v1/time.proto";
 // Transport Search Parameters
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/search_parameters_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/search_parameters_types.proto.dot.svg)
 message TransportSearchParameters {
   // Specify one or more type codes to be included in the search response

--- a/proto/cmp/services/transport/v1/search_result_types.proto
+++ b/proto/cmp/services/transport/v1/search_result_types.proto
@@ -14,6 +14,7 @@ import "cmp/types/v1/rate.proto";
 // Transport search result
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/search_result_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/search_result_types.proto.dot.svg)
 message TransportSearchResult {
   // Unique result ID

--- a/proto/cmp/services/transport/v1/trip_types.proto
+++ b/proto/cmp/services/transport/v1/trip_types.proto
@@ -14,6 +14,7 @@ import "google/protobuf/timestamp.proto";
 // This message type represents a one way trip, either travelling or returning.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/trip_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/trip_types.proto.dot.svg)
 message Trip {
   // Departure and Arrival dates and times can be derrived from the first and last segments

--- a/proto/cmp/services/transport/v2/search.proto
+++ b/proto/cmp/services/transport/v2/search.proto
@@ -68,6 +68,7 @@ message TransportSearchResponse {
 // message type.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search.proto.dot.svg)
 service TransportSearchService {
   rpc TransportSearch(TransportSearchRequest) returns (TransportSearchResponse);

--- a/proto/cmp/services/transport/v2/search.proto
+++ b/proto/cmp/services/transport/v2/search.proto
@@ -67,8 +67,8 @@ message TransportSearchResponse {
 // Takes `TransportSearchRequest` message type and returns `TransportSearchResponse`
 // message type.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/search.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/search.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search.proto.dot.svg)
 service TransportSearchService {
   rpc TransportSearch(TransportSearchRequest) returns (TransportSearchResponse);
 }

--- a/proto/cmp/services/transport/v2/search_parameters_types.proto
+++ b/proto/cmp/services/transport/v2/search_parameters_types.proto
@@ -10,6 +10,7 @@ import "cmp/types/v2/product_code.proto";
 // Transport Search Parameters
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_parameters_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_parameters_types.proto.dot.svg)
 message TransportSearchParameters {
   // Specify one or more type codes to be included in the search response

--- a/proto/cmp/services/transport/v2/search_parameters_types.proto
+++ b/proto/cmp/services/transport/v2/search_parameters_types.proto
@@ -9,8 +9,8 @@ import "cmp/types/v2/product_code.proto";
 
 // Transport Search Parameters
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/search_parameters_types.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/search_parameters_types.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_parameters_types.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_parameters_types.proto.dot.svg)
 message TransportSearchParameters {
   // Specify one or more type codes to be included in the search response
   // Ex: code "EW" number "1234" of the type "IATA"

--- a/proto/cmp/services/transport/v2/search_query_types.proto
+++ b/proto/cmp/services/transport/v2/search_query_types.proto
@@ -15,9 +15,9 @@ import "cmp/types/v2/traveller.proto";
 // - 2 trips in trips: Roundtrip journey from PMI to BCN and then BCN to PMI.
 // - 3 trips in trips: PMI->BCN + BCN->BER + BER->PMI (1 two legged flight (connection) and 1 direct (return) flight)
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/search_query_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_query_types.proto.dot.xs.svg)
 // [Open Message
-// Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/search_query_types.proto.dot.svg)
+// Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_query_types.proto.dot.svg)
 message TransportSearchQuery {
   // ID
   int32 query_id = 1;

--- a/proto/cmp/services/transport/v2/search_result_types.proto
+++ b/proto/cmp/services/transport/v2/search_result_types.proto
@@ -14,6 +14,7 @@ import "cmp/types/v2/price.proto";
 // Transport search result
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_result_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_result_types.proto.dot.svg)
 message TransportSearchResult {
   // Unique result ID

--- a/proto/cmp/services/transport/v2/search_result_types.proto
+++ b/proto/cmp/services/transport/v2/search_result_types.proto
@@ -13,8 +13,8 @@ import "cmp/types/v2/price.proto";
 
 // Transport search result
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/search_result_types.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/search_result_types.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_result_types.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_result_types.proto.dot.svg)
 message TransportSearchResult {
   // Unique result ID
   int32 result_id = 1;

--- a/proto/cmp/services/transport/v2/trip_types.proto
+++ b/proto/cmp/services/transport/v2/trip_types.proto
@@ -14,6 +14,7 @@ import "google/protobuf/timestamp.proto";
 // This message type represents a one way trip, either travelling or returning.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/trip_types.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/trip_types.proto.dot.svg)
 message Trip {
   // Departure and Arrival dates and times can be derrived from the first and last segments

--- a/proto/cmp/services/transport/v2/trip_types.proto
+++ b/proto/cmp/services/transport/v2/trip_types.proto
@@ -13,8 +13,8 @@ import "google/protobuf/timestamp.proto";
 
 // This message type represents a one way trip, either travelling or returning.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/trip_types.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/trip_types.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/trip_types.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/trip_types.proto.dot.svg)
 message Trip {
   // Departure and Arrival dates and times can be derrived from the first and last segments
   // Trip segments are the legs offered

--- a/proto/cmp/types/v1/address.proto
+++ b/proto/cmp/types/v1/address.proto
@@ -7,6 +7,7 @@ import "cmp/types/v1/location.proto";
 // This type represents an address for places like a home or hotel etc.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/address.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/address.proto.dot.svg)
 message Address {
   string line_1 = 1;

--- a/proto/cmp/types/v1/amenity.proto
+++ b/proto/cmp/types/v1/amenity.proto
@@ -32,6 +32,7 @@ package cmp.types.v1;
 // ```
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/amenity.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/amenity.proto.dot.svg)
 message Amenity {
   // Amenity type like INTERNET, POOL, FOOD_BEVERAGE

--- a/proto/cmp/types/v1/baggage.proto
+++ b/proto/cmp/types/v1/baggage.proto
@@ -7,6 +7,7 @@ import "cmp/types/v1/measurement.proto";
 // Baggage message type
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/baggage.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/baggage.proto.dot.svg)
 message Baggage {
   // Baggage type

--- a/proto/cmp/types/v1/bed.proto
+++ b/proto/cmp/types/v1/bed.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package cmp.types.v1;
 
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/bed.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/bed.proto.dot.svg)
 message Bed {
   cmp.types.v1.BedType type = 1;

--- a/proto/cmp/types/v1/bookability.proto
+++ b/proto/cmp/types/v1/bookability.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 import "cmp/types/v1/time.proto";
 
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/bookability.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/bookability.proto.dot.svg)
 message Bookability {
   cmp.types.v1.BookabilityType type = 1;

--- a/proto/cmp/types/v1/cancel_policy.proto
+++ b/proto/cmp/types/v1/cancel_policy.proto
@@ -13,6 +13,7 @@ import "google/protobuf/timestamp.proto";
 // - Complete cancellation policies with from/to DateTime stamps
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/cancel_policy.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/cancel_policy.proto.dot.svg)
 message CancelPolicy {
   // the search result is refundable or not (at least one cancellation penalty exists

--- a/proto/cmp/types/v1/change_policy.proto
+++ b/proto/cmp/types/v1/change_policy.proto
@@ -13,6 +13,7 @@ import "google/protobuf/timestamp.proto";
 // - Multiple change types with start/end DateTime stamps for a search result
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/change_policy.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/change_policy.proto.dot.svg)
 message ChangePolicy {
   // the search result is changeable or not (at least one change type exists)

--- a/proto/cmp/types/v1/common.proto
+++ b/proto/cmp/types/v1/common.proto
@@ -33,6 +33,7 @@ package cmp.types.v1;
 // ### CM Message Header
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/common.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/common.proto.dot.svg)
 message Header {
   // Bot Version The request and response should always hold the bot version used

--- a/proto/cmp/types/v1/contact_info.proto
+++ b/proto/cmp/types/v1/contact_info.proto
@@ -10,6 +10,7 @@ import "cmp/types/v1/phone.proto";
 // Contact Info for general use.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/contact_info.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/contact_info.proto.dot.svg)
 message ContactInfo {
   // Address

--- a/proto/cmp/types/v1/content_source.proto
+++ b/proto/cmp/types/v1/content_source.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Content Source Type message type. TODO: Add documentation to explain the purpose of this message
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/content_source.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/content_source.proto.dot.svg)
 enum ContentSourceType {
   CONTENT_SOURCE_TYPE_UNSPECIFIED = 0;

--- a/proto/cmp/types/v1/country.proto
+++ b/proto/cmp/types/v1/country.proto
@@ -6,6 +6,7 @@ package cmp.types.v1;
 // first, using fewer bytes in the code thus reducing message size.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/country.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/country.proto.dot.svg)
 enum Country {
   COUNTRY_UNSPECIFIED = 0;

--- a/proto/cmp/types/v1/currency.proto
+++ b/proto/cmp/types/v1/currency.proto
@@ -22,6 +22,7 @@ message Currency {
 // optimize the size of the protobuf message size.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/currency.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/currency.proto.dot.svg)
 enum IsoCurrency {
   ISO_CURRENCY_UNSPECIFIED = 0; // Placeholder or unspecified currency

--- a/proto/cmp/types/v1/date.proto
+++ b/proto/cmp/types/v1/date.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Date message that includes year, month and day as integers.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/date.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/date.proto.dot.svg)
 message Date {
   int32 year = 1;

--- a/proto/cmp/types/v1/datetime_range.proto
+++ b/proto/cmp/types/v1/datetime_range.proto
@@ -7,6 +7,7 @@ import "google/protobuf/timestamp.proto";
 // Date range message that includes start and end datetime as timestamps.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/datetime_range.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/datetime_range.proto.dot.svg)
 message DateTimeRange {
   google.protobuf.Timestamp start_datetime = 1;

--- a/proto/cmp/types/v1/delivery.proto
+++ b/proto/cmp/types/v1/delivery.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Delivery Formats and Methods
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/delivery.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/delivery.proto.dot.svg)
 enum DeliveryFormat {
   DELIVERY_FORMAT_UNSPECIFIED = 0;

--- a/proto/cmp/types/v1/description.proto
+++ b/proto/cmp/types/v1/description.proto
@@ -7,6 +7,7 @@ import "cmp/types/v1/language.proto";
 // Localized description set for a given language
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/description.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/description.proto.dot.svg)
 message LocalizedDescriptionSet {
   // Language

--- a/proto/cmp/types/v1/document.proto
+++ b/proto/cmp/types/v1/document.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Document type to be used in various messages
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/document.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/document.proto.dot.svg)
 message Document {
   string document_number = 1;

--- a/proto/cmp/types/v1/dow.proto
+++ b/proto/cmp/types/v1/dow.proto
@@ -26,6 +26,7 @@ package cmp.types.v1;
 // | Result   | 64        | 32         | 16       | 8          | 4         | 2         | 1        |
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/dow.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/dow.proto.dot.svg)
 message DayOfWeek {
   int32 dow = 1;

--- a/proto/cmp/types/v1/duration.proto
+++ b/proto/cmp/types/v1/duration.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Time duration in minutes
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/duration.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/duration.proto.dot.svg)
 message Duration {
   int32 minutes = 1;

--- a/proto/cmp/types/v1/email.proto
+++ b/proto/cmp/types/v1/email.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Email type for general use.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/email.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/email.proto.dot.svg)
 message Email {
   string address = 1;

--- a/proto/cmp/types/v1/file.proto
+++ b/proto/cmp/types/v1/file.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 import "google/protobuf/timestamp.proto";
 
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/file.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/file.proto.dot.svg)
 message File {
   // file name

--- a/proto/cmp/types/v1/filter.proto
+++ b/proto/cmp/types/v1/filter.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Upfront filtering of possible search options in the search response
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/filter.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/filter.proto.dot.svg)
 message Filter {
   // Filters can be based on a type of a specific code standard or codes agreed

--- a/proto/cmp/types/v1/inclusivity.proto
+++ b/proto/cmp/types/v1/inclusivity.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // An Option to specify if an item is included or not included in the context
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/inclusivity.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/inclusivity.proto.dot.svg)
 enum Inclusivity {
   INCLUSIVITY_UNSPECIFIED = 0;

--- a/proto/cmp/types/v1/language.proto
+++ b/proto/cmp/types/v1/language.proto
@@ -7,6 +7,7 @@ package cmp.types.v1;
 // less bytes for this field.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/language.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/language.proto.dot.svg)
 enum Language {
   LANGUAGE_UNSPECIFIED = 0;

--- a/proto/cmp/types/v1/link.proto
+++ b/proto/cmp/types/v1/link.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Link is used to represent websites, social media contact, online check-in url, ... etc
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/link.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/link.proto.dot.svg)
 message Link {
   // Link type

--- a/proto/cmp/types/v1/location.proto
+++ b/proto/cmp/types/v1/location.proto
@@ -10,6 +10,7 @@ import "cmp/types/v1/measurement.proto";
 // Represents a geographic location
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/location.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/location.proto.dot.svg)
 message Coordinates {
   // The latitude in degrees. It must be in the range [-90.0, +90.0].

--- a/proto/cmp/types/v1/loyalty_program.proto
+++ b/proto/cmp/types/v1/loyalty_program.proto
@@ -7,6 +7,7 @@ import "cmp/types/v1/link.proto";
 // Loyalty Program
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/loyalty_program.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/loyalty_program.proto.dot.svg)
 message LoyaltyProgram {
   // In case of an off-chain loyalty program, this is the id of the loyalty program in loyalty system

--- a/proto/cmp/types/v1/meal_plan.proto
+++ b/proto/cmp/types/v1/meal_plan.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Meal Plan message type
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/meal_plan.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/meal_plan.proto.dot.svg)
 message MealPlan {
   // Meal Plan Code

--- a/proto/cmp/types/v1/measurement.proto
+++ b/proto/cmp/types/v1/measurement.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Length
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/measurement.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/measurement.proto.dot.svg)
 message Length {
   int32 value = 1;

--- a/proto/cmp/types/v1/partner.proto
+++ b/proto/cmp/types/v1/partner.proto
@@ -8,6 +8,7 @@ import "cmp/types/v1/wallet.proto";
 // ### Partner message type
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/partner.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/partner.proto.dot.svg)
 message Partner {
   // Short name of the partner. Ex: Chain4Travel

--- a/proto/cmp/types/v1/phone.proto
+++ b/proto/cmp/types/v1/phone.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Phone type to be used in various types as hotels, holiday homes etc.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/phone.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/phone.proto.dot.svg)
 message Phone {
   string number = 1;

--- a/proto/cmp/types/v1/price.proto
+++ b/proto/cmp/types/v1/price.proto
@@ -14,6 +14,7 @@ import "cmp/types/v1/price_type.proto";
 // pricing structures can be represented.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/price.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/price.proto.dot.svg)
 message PriceDetail {
   // Principle price element

--- a/proto/cmp/types/v1/product_code.proto
+++ b/proto/cmp/types/v1/product_code.proto
@@ -7,6 +7,7 @@ package cmp.types.v1;
 // This is being used in requests to specify the a list of products to be included in the reponse
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/product_code.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/product_code.proto.dot.svg)
 message ProductCode {
   // In most cases like in accommodation, just the field "code" and "type" will be

--- a/proto/cmp/types/v1/product_status.proto
+++ b/proto/cmp/types/v1/product_status.proto
@@ -7,6 +7,7 @@ package cmp.types.v1;
 // This is being used in responses to specify the status of a product of any message type.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/product_status.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/product_status.proto.dot.svg)
 enum ProductStatus {
   PRODUCT_STATUS_UNSPECIFIED = 0;

--- a/proto/cmp/types/v1/rate.proto
+++ b/proto/cmp/types/v1/rate.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Rate Rule
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/rate.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/rate.proto.dot.svg)
 message RateRule {
   // RateRule

--- a/proto/cmp/types/v1/redemption.proto
+++ b/proto/cmp/types/v1/redemption.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Redemption Methods
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/redemption.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/redemption.proto.dot.svg)
 enum RedemptionMethod {
   REDEMPTION_METHOD_UNSPECIFIED = 0;

--- a/proto/cmp/types/v1/search.proto
+++ b/proto/cmp/types/v1/search.proto
@@ -13,6 +13,7 @@ import "cmp/types/v1/uuid.proto";
 // Search parameters for the search requests
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/search.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/search.proto.dot.svg)
 message SearchParameters {
   // Requested currency in which prices have to be supplied in the response

--- a/proto/cmp/types/v1/seat_map.proto
+++ b/proto/cmp/types/v1/seat_map.proto
@@ -76,6 +76,7 @@ message Section {
 // seating arrangement, including sections, images, and localized descriptions.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/seat_map.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/seat_map.proto.dot.svg)
 message SeatMap {
   // Unique identifier for the seat map

--- a/proto/cmp/types/v1/service_fact.proto
+++ b/proto/cmp/types/v1/service_fact.proto
@@ -18,6 +18,7 @@ import "cmp/types/v1/price.proto";
 //
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/service_fact.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/service_fact.proto.dot.svg)
 message ServiceFact {
   // A code for the specific service, when a service is optional, this code is

--- a/proto/cmp/types/v1/sorting.proto
+++ b/proto/cmp/types/v1/sorting.proto
@@ -7,6 +7,7 @@ package cmp.types.v1;
 // This is being used in requests to specify the sorting required in the response.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/sorting.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/sorting.proto.dot.svg)
 message Sorting {
   cmp.types.v1.SortingType sorting_type = 1;

--- a/proto/cmp/types/v1/time.proto
+++ b/proto/cmp/types/v1/time.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Time Message
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/time.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/time.proto.dot.svg)
 message Time {
   int32 hours = 1;

--- a/proto/cmp/types/v1/token.proto
+++ b/proto/cmp/types/v1/token.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Token Reference
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/token.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/token.proto.dot.svg)
 message TokenCurrency {
   string contract_address = 1;

--- a/proto/cmp/types/v1/travel_period.proto
+++ b/proto/cmp/types/v1/travel_period.proto
@@ -8,6 +8,7 @@ import "cmp/types/v1/dow.proto";
 // Travel Period
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/travel_period.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/travel_period.proto.dot.svg)
 message TravelPeriod {
   // Start date of a trip for messages where no Date/Time is required

--- a/proto/cmp/types/v1/traveller.proto
+++ b/proto/cmp/types/v1/traveller.proto
@@ -10,6 +10,7 @@ import "cmp/types/v1/document.proto";
 // Traveller
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/traveller.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/traveller.proto.dot.svg)
 message BasicTraveller {
   // Guest number, the lowest number is the lead-pax. This ID is also used for

--- a/proto/cmp/types/v1/uuid.proto
+++ b/proto/cmp/types/v1/uuid.proto
@@ -7,6 +7,7 @@ package cmp.types.v1;
 // This must be a UUID according to RFC 4122 standard.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/uuid.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/uuid.proto.dot.svg)
 message UUID {
   string value = 1;

--- a/proto/cmp/types/v1/wallet.proto
+++ b/proto/cmp/types/v1/wallet.proto
@@ -5,6 +5,7 @@ package cmp.types.v1;
 // Address and public key for a wallet
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/wallet.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/wallet.proto.dot.svg)
 message WalletAddress {
   // Wallet address

--- a/proto/cmp/types/v2/address.proto
+++ b/proto/cmp/types/v2/address.proto
@@ -7,6 +7,7 @@ import "cmp/types/v2/location.proto";
 // This type represents an address for places like a home or hotel etc.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/address.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/address.proto.dot.svg)
 message Address {
   string line_1 = 1;

--- a/proto/cmp/types/v2/address.proto
+++ b/proto/cmp/types/v2/address.proto
@@ -6,8 +6,8 @@ import "cmp/types/v2/location.proto";
 
 // This type represents an address for places like a home or hotel etc.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/address.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/address.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/address.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/address.proto.dot.svg)
 message Address {
   string line_1 = 1;
   string line_2 = 2;

--- a/proto/cmp/types/v2/cancel_policy.proto
+++ b/proto/cmp/types/v2/cancel_policy.proto
@@ -12,8 +12,8 @@ import "google/protobuf/timestamp.proto";
 // - A "free cancellation upto" DateTime
 // - Complete cancellation policies with from/to DateTime stamps
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/cancel_policy.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/cancel_policy.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/cancel_policy.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/cancel_policy.proto.dot.svg)
 message CancelPolicy {
   // the search result is refundable or not (at least one cancellation penalty exists
   // that provides a (partial) refund)

--- a/proto/cmp/types/v2/cancel_policy.proto
+++ b/proto/cmp/types/v2/cancel_policy.proto
@@ -13,6 +13,7 @@ import "google/protobuf/timestamp.proto";
 // - Complete cancellation policies with from/to DateTime stamps
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/cancel_policy.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/cancel_policy.proto.dot.svg)
 message CancelPolicy {
   // the search result is refundable or not (at least one cancellation penalty exists

--- a/proto/cmp/types/v2/change_policy.proto
+++ b/proto/cmp/types/v2/change_policy.proto
@@ -12,8 +12,8 @@ import "google/protobuf/timestamp.proto";
 // - A "free change upto" DateTime for a search result
 // - Multiple change types with start/end DateTime stamps for a search result
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/change_policy.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/change_policy.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/change_policy.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/change_policy.proto.dot.svg)
 message ChangePolicy {
   // the search result is changeable or not (at least one change type exists)
   bool change_allowed = 1;

--- a/proto/cmp/types/v2/change_policy.proto
+++ b/proto/cmp/types/v2/change_policy.proto
@@ -13,6 +13,7 @@ import "google/protobuf/timestamp.proto";
 // - Multiple change types with start/end DateTime stamps for a search result
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/change_policy.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/change_policy.proto.dot.svg)
 message ChangePolicy {
   // the search result is changeable or not (at least one change type exists)

--- a/proto/cmp/types/v2/contact_info.proto
+++ b/proto/cmp/types/v2/contact_info.proto
@@ -10,6 +10,7 @@ import "cmp/types/v2/email.proto";
 // Contact Info for general use.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/contact_info.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/contact_info.proto.dot.svg)
 message ContactInfo {
   // Address

--- a/proto/cmp/types/v2/contact_info.proto
+++ b/proto/cmp/types/v2/contact_info.proto
@@ -9,8 +9,8 @@ import "cmp/types/v2/email.proto";
 
 // Contact Info for general use.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/contact_info.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/contact_info.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/contact_info.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/contact_info.proto.dot.svg)
 message ContactInfo {
   // Address
   repeated cmp.types.v2.Address address = 1;

--- a/proto/cmp/types/v2/country.proto
+++ b/proto/cmp/types/v2/country.proto
@@ -6,6 +6,7 @@ package cmp.types.v2;
 // first, using fewer bytes in the code thus reducing message size.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/country.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/country.proto.dot.svg)
 enum Country {
   COUNTRY_UNSPECIFIED = 0;

--- a/proto/cmp/types/v2/currency.proto
+++ b/proto/cmp/types/v2/currency.proto
@@ -22,6 +22,7 @@ message Currency {
 // optimize the size of the protobuf message size.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/currency.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/currency.proto.dot.svg)
 enum IsoCurrency {
   ISO_CURRENCY_UNSPECIFIED = 0; // Placeholder or unspecified currency

--- a/proto/cmp/types/v2/currency.proto
+++ b/proto/cmp/types/v2/currency.proto
@@ -21,8 +21,8 @@ message Currency {
 // First 20 currencies are the most traded currencies in the world. This is done to
 // optimize the size of the protobuf message size.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/currency.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/currency.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/currency.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/currency.proto.dot.svg)
 enum IsoCurrency {
   ISO_CURRENCY_UNSPECIFIED = 0; // Placeholder or unspecified currency
 

--- a/proto/cmp/types/v2/email.proto
+++ b/proto/cmp/types/v2/email.proto
@@ -4,8 +4,8 @@ package cmp.types.v2;
 
 // Email type for general use.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/email.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/email.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/email.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/email.proto.dot.svg)
 message Email {
   string address = 1;
 

--- a/proto/cmp/types/v2/email.proto
+++ b/proto/cmp/types/v2/email.proto
@@ -5,6 +5,7 @@ package cmp.types.v2;
 // Email type for general use.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/email.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/email.proto.dot.svg)
 message Email {
   string address = 1;

--- a/proto/cmp/types/v2/file.proto
+++ b/proto/cmp/types/v2/file.proto
@@ -4,8 +4,8 @@ package cmp.types.v2;
 
 import "google/protobuf/timestamp.proto";
 
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/file.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/file.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/file.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/file.proto.dot.svg)
 message File {
   // file name
   string name = 1;

--- a/proto/cmp/types/v2/file.proto
+++ b/proto/cmp/types/v2/file.proto
@@ -5,6 +5,7 @@ package cmp.types.v2;
 import "google/protobuf/timestamp.proto";
 
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/file.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/file.proto.dot.svg)
 message File {
   // file name

--- a/proto/cmp/types/v2/location.proto
+++ b/proto/cmp/types/v2/location.proto
@@ -10,6 +10,7 @@ import "cmp/types/v2/country.proto";
 // Represents a geographic location
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/location.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/location.proto.dot.svg)
 message Coordinates {
   // The latitude in degrees. It must be in the range [-90.0, +90.0].

--- a/proto/cmp/types/v2/location.proto
+++ b/proto/cmp/types/v2/location.proto
@@ -9,8 +9,8 @@ import "cmp/types/v2/country.proto";
 //
 // Represents a geographic location
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/location.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/location.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/location.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/location.proto.dot.svg)
 message Coordinates {
   // The latitude in degrees. It must be in the range [-90.0, +90.0].
   double latitude = 1;

--- a/proto/cmp/types/v2/partner.proto
+++ b/proto/cmp/types/v2/partner.proto
@@ -7,8 +7,8 @@ import "cmp/types/v2/token.proto";
 
 // ### Partner message type
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/partner.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/partner.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/partner.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/partner.proto.dot.svg)
 message Partner {
   // Short name of the partner. Ex: Chain4Travel
   string short_name = 1;

--- a/proto/cmp/types/v2/partner.proto
+++ b/proto/cmp/types/v2/partner.proto
@@ -8,6 +8,7 @@ import "cmp/types/v2/token.proto";
 // ### Partner message type
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/partner.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/partner.proto.dot.svg)
 message Partner {
   // Short name of the partner. Ex: Chain4Travel

--- a/proto/cmp/types/v2/price.proto
+++ b/proto/cmp/types/v2/price.proto
@@ -13,8 +13,8 @@ import "cmp/types/v2/currency.proto";
 // Breakdown is a recursively inherited object of PriceDetail. This way complex
 // pricing structures can be represented.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/price.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/price.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/price.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/price.proto.dot.svg)
 message PriceDetail {
   // Principle price element
   cmp.types.v2.Price price = 1;

--- a/proto/cmp/types/v2/price.proto
+++ b/proto/cmp/types/v2/price.proto
@@ -14,6 +14,7 @@ import "cmp/types/v2/currency.proto";
 // pricing structures can be represented.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/price.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/price.proto.dot.svg)
 message PriceDetail {
   // Principle price element

--- a/proto/cmp/types/v2/product_code.proto
+++ b/proto/cmp/types/v2/product_code.proto
@@ -7,6 +7,7 @@ package cmp.types.v2;
 // This is being used in requests to specify the a list of products to be included in the reponse
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/product_code.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/product_code.proto.dot.svg)
 message ProductCode {
   // In most cases like in accommodation, just the field "code" and "type" will be

--- a/proto/cmp/types/v2/search.proto
+++ b/proto/cmp/types/v2/search.proto
@@ -13,6 +13,7 @@ import "cmp/types/v2/currency.proto";
 // Search parameters for the search requests
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/search.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/search.proto.dot.svg)
 message SearchParameters {
   // Requested currency in which prices have to be supplied in the response

--- a/proto/cmp/types/v2/search.proto
+++ b/proto/cmp/types/v2/search.proto
@@ -12,8 +12,8 @@ import "cmp/types/v2/currency.proto";
 
 // Search parameters for the search requests
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/search.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/search.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/search.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/search.proto.dot.svg)
 message SearchParameters {
   // Requested currency in which prices have to be supplied in the response
   // according to ISO 4217 Currency codes

--- a/proto/cmp/types/v2/seat_map.proto
+++ b/proto/cmp/types/v2/seat_map.proto
@@ -76,6 +76,7 @@ message Section {
 // seating arrangement, including sections, images, and localized descriptions.
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/seat_map.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/seat_map.proto.dot.svg)
 message SeatMap {
   // Unique identifier for the seat map

--- a/proto/cmp/types/v2/seat_map.proto
+++ b/proto/cmp/types/v2/seat_map.proto
@@ -75,8 +75,8 @@ message Section {
 // of seating within a venue. This message provides a comprehensive overview of the
 // seating arrangement, including sections, images, and localized descriptions.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/seat_map.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/seat_map.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/seat_map.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/seat_map.proto.dot.svg)
 message SeatMap {
   // Unique identifier for the seat map
   string id = 1;

--- a/proto/cmp/types/v2/service_fact.proto
+++ b/proto/cmp/types/v2/service_fact.proto
@@ -17,8 +17,8 @@ import "cmp/types/v2/price.proto";
 // which ski pass and what level of ski class that be properly selected.
 //
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/service_fact.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/service_fact.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/service_fact.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/service_fact.proto.dot.svg)
 message ServiceFact {
   // A code for the specific service, when a service is optional, this code is
   // referenced in the validate request, so that the optional service will be added

--- a/proto/cmp/types/v2/service_fact.proto
+++ b/proto/cmp/types/v2/service_fact.proto
@@ -18,6 +18,7 @@ import "cmp/types/v2/price.proto";
 //
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/service_fact.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/service_fact.proto.dot.svg)
 message ServiceFact {
   // A code for the specific service, when a service is optional, this code is

--- a/proto/cmp/types/v2/token.proto
+++ b/proto/cmp/types/v2/token.proto
@@ -4,8 +4,8 @@ package cmp.types.v2;
 
 // Token Reference
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/token.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/token.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/token.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/token.proto.dot.svg)
 message TokenCurrency {
   string contract_address = 1;
 }

--- a/proto/cmp/types/v2/token.proto
+++ b/proto/cmp/types/v2/token.proto
@@ -5,6 +5,7 @@ package cmp.types.v2;
 // Token Reference
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/token.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/token.proto.dot.svg)
 message TokenCurrency {
   string contract_address = 1;

--- a/proto/cmp/types/v2/traveller.proto
+++ b/proto/cmp/types/v2/traveller.proto
@@ -9,8 +9,8 @@ import "cmp/types/v2/country.proto";
 
 // Traveller
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/traveller.proto.dot.xs.svg)
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/traveller.proto.dot.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/traveller.proto.dot.xs.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/traveller.proto.dot.svg)
 message BasicTraveller {
   // Guest number, the lowest number is the lead-pax. This ID is also used for
   // referencing services linked to specific participants, like baggage.

--- a/proto/cmp/types/v2/traveller.proto
+++ b/proto/cmp/types/v2/traveller.proto
@@ -10,6 +10,7 @@ import "cmp/types/v2/country.proto";
 // Traveller
 //
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/traveller.proto.dot.xs.svg)
+//
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/traveller.proto.dot.svg)
 message BasicTraveller {
   // Guest number, the lowest number is the lead-pax. This ID is also used for


### PR DESCRIPTION
This PR:
- fixes incorrect diagram link in the v2 packages.
- add an extra line between diagram image and link

> [!TIP]
> Find all files under matching `*/v2/*.proto` and and replace the `v1` in the URL with `v2`:
> ```bash
> find . -type f -path "*/v2/*.proto" -exec sed -E 's#(/)v1(/[^/]*proto\.dot[^)]*\.svg\))#\1v2\2#g' -i {} +
> ```