### PR TITLE
Rearrance trip types to remove redundant info

### DIFF
--- a/proto/cmp/services/transport/v1/list.proto
+++ b/proto/cmp/services/transport/v1/list.proto
@@ -24,9 +24,9 @@ message TransportProductListResponse {
 
 // This service is used to get a product list for transportation.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/list.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/list.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/list.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v1/list.proto.dot.svg)
 service TransportProductListService {
   // Gets an optional `modified_after` date and returns a product list.
   rpc TransportProductList(TransportProductListRequest) returns (TransportProductListResponse);

--- a/proto/cmp/services/transport/v1/list.proto
+++ b/proto/cmp/services/transport/v1/list.proto
@@ -19,7 +19,7 @@ message TransportProductListResponse {
   cmp.types.v1.ResponseHeader header = 1;
 
   // Product list: Trips
-  repeated cmp.services.transport.v3.TripSchedule trips = 2;
+  repeated cmp.services.transport.v3.TripBasic trips = 2;
 }
 
 // This service is used to get a product list for transportation.

--- a/proto/cmp/services/transport/v3/search_result_types.proto
+++ b/proto/cmp/services/transport/v3/search_result_types.proto
@@ -39,7 +39,7 @@ message TransportSearchResult {
   // we rent a car and do a road trip to San Fransisco and we take a flight from SFO
   // to SYD, where afer a couple of days we move on to Indonesia, Thailand, Japan,
   // Türkiye and back to Amsterdam again.
-  repeated cmp.services.transport.v3.Trip travelling_trips = 5;
+  repeated cmp.services.transport.v3.TripExtended travelling_trips = 5;
 
   // Total Price
   cmp.types.v2.PriceDetail total_price = 6;

--- a/proto/cmp/services/transport/v3/trip_types.proto
+++ b/proto/cmp/services/transport/v3/trip_types.proto
@@ -17,8 +17,8 @@ import "google/protobuf/timestamp.proto";
 //
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/trip_types.proto.dot.svg)
 message TripExtended {
-  // Schedule for the whole trip
-  cmp.services.transport.v3.TripInfo info = 1;
+  // Trip supplier code
+  cmp.types.v2.SupplierProductCode supplier_code = 1;
 
   // Luggage
   //
@@ -30,7 +30,7 @@ message TripExtended {
   // Ex: `Price(net=240, currency=Currency.CURRENCY_EUR)
   cmp.types.v2.Price price = 3;
 
-  // Trip segments are the legs offered
+  // Trip segments are the legs offered. Here we use extended segments type.
   //
   // Departure and Arrival dates and times can be derived from the first and last segments
   repeated cmp.services.transport.v3.SegmentExtended segments = 4;
@@ -40,21 +40,13 @@ message TripExtended {
 //
 // Intended to be used in list service.
 message TripBasic {
-  // Trip Info like carrier code, carrier type, period
-  cmp.services.transport.v3.TripInfo info = 1;
+  // Trip supplier code
+  cmp.types.v2.SupplierProductCode supplier_code = 1;
 
   // Trip segments are the legs offered
   //
   // Departure and Arrival dates and times can be derived from the first and last segments
   repeated cmp.services.transport.v3.Segment segments = 2;
-}
-
-message TripInfo {
-  // Carrier Code
-  string carrier_code = 1;
-
-  // Carrier Type. Ex: airline, transfer company, train company, .. etc
-  string carrier_type = 2;
 }
 
 // A segment of a trip

--- a/proto/cmp/services/transport/v3/trip_types.proto
+++ b/proto/cmp/services/transport/v3/trip_types.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package cmp.services.transport.v3;
 
 import "cmp/types/v1/baggage.proto";
-import "cmp/types/v1/datetime_range.proto";
 import "cmp/types/v1/duration.proto";
 import "cmp/types/v1/measurement.proto";
 import "cmp/types/v2/location.proto";
@@ -17,9 +16,9 @@ import "google/protobuf/timestamp.proto";
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/trip_types.proto.dot.xs.svg)
 //
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/trip_types.proto.dot.svg)
-message Trip {
+message TripExtended {
   // Schedule for the whole trip
-  cmp.services.transport.v3.TripSchedule schedule = 1;
+  cmp.services.transport.v3.TripInfo info = 1;
 
   // Luggage
   //
@@ -31,24 +30,37 @@ message Trip {
   // Ex: `Price(net=240, currency=Currency.CURRENCY_EUR)
   cmp.types.v2.Price price = 3;
 
-  // Departure and Arrival dates and times can be derived from the first and last segments
   // Trip segments are the legs offered
-  repeated cmp.services.transport.v3.TripSegment segments = 4;
+  //
+  // Departure and Arrival dates and times can be derived from the first and last segments
+  repeated cmp.services.transport.v3.SegmentExtended segments = 4;
 }
 
-// Represents a departure or arrival event
-message TransitEvent {
-  // Date time of the event
-  google.protobuf.Timestamp date_time = 1;
+// A whole trip from the first segment till the last one with basic information.
+//
+// Intended to be used in list service.
+message TripBasic {
+  // Trip Info like carrier code, carrier type, period
+  cmp.services.transport.v3.TripInfo info = 1;
 
-  // Event location
-  cmp.types.v2.LocationCode location_code = 2;
+  // Trip segments are the legs offered
+  //
+  // Departure and Arrival dates and times can be derived from the first and last segments
+  repeated cmp.services.transport.v3.Segment segments = 2;
+}
+
+message TripInfo {
+  // Carrier Code
+  string carrier_code = 1;
+
+  // Carrier Type. Ex: airline, transfer company, train company, .. etc
+  string carrier_type = 2;
 }
 
 // A segment of a trip
-message TripSegment {
+message SegmentExtended {
   // Segment Info
-  cmp.services.transport.v3.SegmentInfo info = 1;
+  cmp.services.transport.v3.Segment info = 1;
 
   // Flights, trains and transfers often offer different service types
   // for a product. Think about economy or business for flights, first and second
@@ -82,22 +94,7 @@ message TripSegment {
   int32 max_pax = 6;
 }
 
-// A whole trip schedule from the first segment till the last one
-message TripSchedule {
-  // Carrier Code
-  string carrier_code = 1;
-
-  // Carrier Type. Ex: airline, transfer company, train company, .. etc
-  string carrier_type = 2;
-
-  // Start and end datetime for the trip
-  cmp.types.v1.DateTimeRange period = 3;
-
-  // Schedule for each segment of the trip
-  repeated cmp.services.transport.v3.SegmentInfo segments = 4;
-}
-
-message SegmentInfo {
+message Segment {
   // Segment ID
   // Ex: "SEG1234"
   string segment_id = 1;
@@ -148,4 +145,13 @@ message SegmentInfo {
   //
   // Ex: `Length(value=15, unit=LengthUnit.DISTANCE_UNIT_KILOMETERS)`
   cmp.types.v1.Length segment_distance = 10;
+}
+
+// Represents a departure or arrival event
+message TransitEvent {
+  // Date time of the event
+  google.protobuf.Timestamp date_time = 1;
+
+  // Event location
+  cmp.types.v2.LocationCode location_code = 2;
 }


### PR DESCRIPTION
This PR tries to remove redundant use of segment info in the trip types.