### PR TITLE
Add Camino Messenger Service Tags Specification

### DIFF
--- a/spec/service-tags.md
+++ b/spec/service-tags.md
@@ -1,0 +1,120 @@
+# Camino Messenger Service Tags Specification
+
+## Overview
+
+This specification defines a tagging scheme for Camino Messenger Protocol services
+to distinguish between different message routing patterns and service types. The
+tags follow a similar pattern to NatSpec's custom tags but are specifically designed
+for protobuf service definitions.
+
+## Tag Format
+
+The tag follows this format:
+
+```protobuf
+/// @custom:cmp-service type:{TYPE} routing:{PATTERN} on-chain:[true|false]
+service ServiceName {
+  // service definition
+}
+```
+
+## Service Types
+
+The `type` tag identifies the fundamental nature of the service:
+
+- `core` - Essential protocol services (e.g., ping, network fee)
+- `product` - Product services (e.g., booking, search)
+- `operational` - Operational services (e.g., notifications, monitoring)
+- `system` - System-level services (e.g., health checks, metrics)
+
+## Service Routing Patterns
+
+The `routing` tag defines the message routing pattern:
+
+- `p2p` - Partner-to-Partner communication via messenger server (e.g., search, booking)
+- `local` - Partner-to-Bot communication without server routing (e.g., notification, cancellation)
+
+## Service Blockchain Interaction
+
+The `on-chain` tag identifies if the service does any on-chain action. Possible
+values are `true` and `false`, with `false` being default if the tag is omitted.
+
+- `false` - For services that **do not** trigger any on-chain action (e.g., search, list, info)
+- `true` - For services that does some kind of on-chain action (e.g., mint, cancellation)
+
+## Examples
+
+### P2P Product Service (in package cmp.services.accommodation.v2)
+
+```protobuf
+/// @custom:cmp-service type:product routing:p2p
+service AccommodationSearchService {
+  rpc AccommodationSearch(AccommodationSearchRequest) returns (AccommodationSearchResponse);
+}
+```
+
+### Local Operational Service (in package cmp.services.notification.v1)
+
+```protobuf
+/// @custom:cmp-service type:operational routing:local on-chain:true
+service NotificationService {
+  rpc TokenBoughtNotification(TokenBought) returns (google.protobuf.Empty);
+  rpc TokenExpiredNotification(TokenExpired) returns (google.protobuf.Empty);
+}
+```
+
+### Core System Service (in package cmp.services.ping.v1)
+
+```protobuf
+/// @custom:cmp-service type:core routing:p2p on-chain:false
+service PingService {
+  rpc Ping(PingRequest) returns (PingResponse);
+}
+```
+
+## Implementation Implications
+
+### Code Generation
+
+The tags can be used by code generators to:
+
+1. Generate appropriate routing logic based on pattern
+2. Apply different validation rules
+3. Implement pattern-specific error handling
+4. Add pattern-specific logging/monitoring
+5. Generate client/server stubs with appropriate configurations
+
+### Documentation
+
+These tags should be:
+
+1. Required for all service definitions
+2. Validated via CI
+
+### Validation Rules
+
+Required attributes:
+
+- Every service must have a `@custom:cmp-service` tag
+- The tag must include both `type` and `routing` attributes
+- `routing` must be one of the defined patterns
+- `type` must be one of the defined types
+
+## Migration Guide
+
+To add tags to existing services:
+
+1. Analyze the service's current usage pattern
+2. Determine appropriate type and pattern
+3. Add tags above service definition
+4. Update any code generation scripts
+5. Test generated code for correct routing
+
+## Best Practices
+
+1. Always include both required attributes (type and routing)
+2. Keep attributes in same order for consistency, first `type` then `routing`
+3. Document tag selection rationale in comments
+4. Review tag assignments during service updates
+5. Include tags in service review process
+6. Keep the tag on a single line above the service

--- a/spec/service-tags.md
+++ b/spec/service-tags.md
@@ -23,9 +23,14 @@ service ServiceName {
 The `type` tag identifies the fundamental nature of the service:
 
 - `core` - Essential protocol services (e.g., ping, network fee)
-- `product` - Product services (e.g., booking, search)
-- `operational` - Operational services (e.g., notifications, monitoring)
+- `product` - Product related services (e.g., booking, search, notification,
+  cancellation).
 - `system` - System-level services (e.g., health checks, metrics)
+
+> [!NOTE]
+> Notifications and cancellation services also fall under `product` type because
+> they relate to the product, even if they do not directly communicate between
+> partners via the messenger server.
 
 ## Service Routing Patterns
 
@@ -36,11 +41,13 @@ The `routing` tag defines the message routing pattern:
 
 ## Service Blockchain Interaction
 
-The `on-chain` tag identifies if the service does any on-chain action. Possible
-values are `true` and `false`, with `false` being default if the tag is omitted.
+The `on-chain` tag indicates whether the service interacts with the blockchain in any
+way. Possible values are `true` and `false`, with `false` as the default if the tag is
+omitted.
 
-- `false` - For services that **do not** trigger any on-chain action (e.g., search, list, info)
-- `true` - For services that does some kind of on-chain action (e.g., mint, cancellation)
+- `false` - For services that **do not** interact with the blockchain (e.g., search, list, info)
+- `true` - For services that involve any on-chain interaction, including read or
+  write actions (e.g., listening for events, minting, cancellation)
 
 ## Examples
 
@@ -53,10 +60,10 @@ service AccommodationSearchService {
 }
 ```
 
-### Local Operational Service (in package cmp.services.notification.v1)
+### Local Service (in package cmp.services.notification.v1)
 
 ```protobuf
-/// @custom:cmp-service type:operational routing:local on-chain:true
+/// @custom:cmp-service type:product routing:local on-chain:true
 service NotificationService {
   rpc TokenBoughtNotification(TokenBought) returns (google.protobuf.Empty);
   rpc TokenExpiredNotification(TokenExpired) returns (google.protobuf.Empty);


### PR DESCRIPTION
**Overview:**
This PR introduces the *Camino Messenger Service Tags Specification*, a structured tagging scheme for the Camino Messenger Protocol services, enabling consistent service categorization across Protobuf service definitions. The tags are intended to facilitate automation in code generation.

**Key Additions:**
- **Tag Format**: Introduces a standardized format for service tags that includes `type`, `routing`, and `on-chain` attributes.
- **Service Types**: Defines primary service categories (`core`, `product`, `system`) to distinguish service functions within the protocol.
- **Routing Patterns**: Specifies message routing options (`p2p`, `local`) to clarify communication pathways.
- **Blockchain Interaction**: Establishes the `on-chain` attribute to indicate whether a service performs on-chain read/write actions.

**Examples and Best Practices:**
- Includes practical tag examples for various services, emphasizing tag consistency and documentation requirements.
- Details best practices to maintain a standardized approach in service tagging, including validation rules and migration steps for existing services.

**Implementation Implications:**
- Provides guidance on leveraging tags in code generation, documentation, and validation processes.
- Establishes validation criteria to ensure compliance with the specification in CI workflows.