### PR TITLE
Add cancellable field in the mint response

### DIFF
--- a/proto/cmp/services/book/v2/mint.proto
+++ b/proto/cmp/services/book/v2/mint.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package cmp.services.book.v3;
+package cmp.services.book.v2;
 
 import "cmp/types/v1/common.proto";
 import "cmp/types/v1/language.proto";

--- a/proto/cmp/services/book/v2/mint.proto
+++ b/proto/cmp/services/book/v2/mint.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package cmp.services.book.v2;
+package cmp.services.book.v3;
 
 import "cmp/types/v1/common.proto";
 import "cmp/types/v1/language.proto";

--- a/proto/cmp/services/book/v3/mint.proto
+++ b/proto/cmp/services/book/v3/mint.proto
@@ -96,6 +96,11 @@ message MintResponse {
   //
   // This field is not meant for the supplier.
   cmp.types.v3.EVMTransactionID buy_transaction_id = 11;
+
+  // This field indicates whether the booking can be cancelled. If this field
+  // is not used, the default value is false, whick means the booking cannot be
+  // cancelled.
+  bool cancellable = 12;
 }
 
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v3/mint.proto.dot.xs.svg)

--- a/proto/cmp/services/book/v3/mint.proto
+++ b/proto/cmp/services/book/v3/mint.proto
@@ -97,9 +97,8 @@ message MintResponse {
   // This field is not meant for the supplier.
   cmp.types.v3.EVMTransactionID buy_transaction_id = 11;
 
-  // This field indicates whether the booking can be cancelled. If this field
-  // is not used, the default value is false, whick means the booking cannot be
-  // cancelled.
+  // This field indicates whether the booking can be cancelled. If this field is not
+  // used, the default value is false, which means the booking cannot be cancelled.
   bool cancellable = 12;
 }
 


### PR DESCRIPTION
We added a field in the Mint response to indicate whether a booking can be cancelled. This is backward compatible amendment at the end of the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new field to indicate if a booking can be cancelled in the booking response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->