### PR TITLE
Add diff against dev branch to help with PR reviews

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,19 @@ jobs:
       - name: Run diff against branch
         run: scripts/diff_against_branch.sh
 
+  # diff check against dev branch to help with the PR reviews
+  diff-dev:
+    name: Diff against dev to help with the PR reviews
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+      - name: Run diff against branch
+        run: |
+          scripts/diff_against_branch.sh dev || true
+          echo -e "\n🛟 Note: This diff check against dev branch is for PR review purposes only."
+          echo -e "🛟 Any reported differences are informational and not considered errors.\n"
+
   # dependency check to catch if proto files were not updated correctly
   dependency-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a new job to the CI workflow that will generate a diff for the current PR against `dev` branch instead of `c4t`. This will make it easier to review the PRs because diff against `c4t' is too big most of the time. (Still very helpful to catch breaking changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new CI job named `diff-dev` for enhanced pull request reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->