### PR TITLE
Add EVM Address and EVMTransactionID types

### DIFF
--- a/proto/cmp/services/book/v3/mint.proto
+++ b/proto/cmp/services/book/v3/mint.proto
@@ -6,6 +6,8 @@ import "cmp/types/v1/common.proto";
 import "cmp/types/v1/language.proto";
 import "cmp/types/v1/pubkey.proto";
 import "cmp/types/v1/uuid.proto";
+import "cmp/types/v3/evm_address.proto";
+import "cmp/types/v3/evm_transaction.proto";
 import "cmp/types/v3/payment.proto";
 import "cmp/types/v3/price.proto";
 import "cmp/types/v3/traveller.proto";
@@ -38,7 +40,7 @@ message MintRequest {
 
   // Buyer's address. Only this address should be allowed to buy the `BookingToken`
   // on chain.
-  string buyer_address = 10;
+  cmp.types.v3.EVMAddress buyer_address = 10;
 
   // This field is only relevant for off chain virtual credit card payments.
   cmp.types.v3.AdditionalPaymentInfo additional_payment_info = 11;
@@ -78,7 +80,7 @@ message MintResponse {
 
   // Mint transaction ID that will be populated by the supplier bot after the
   // `BookingToken` is minted on chain.
-  string mint_transaction_id = 9;
+  cmp.types.v3.EVMTransactionID mint_transaction_id = 9;
 
   // On chain booking token should be only buyable until this timestamp and should
   // expire after that.
@@ -93,7 +95,7 @@ message MintResponse {
   // (partner plugin) in the mint response.
   //
   // This field is not meant for the supplier.
-  string buy_transaction_id = 11;
+  cmp.types.v3.EVMTransactionID buy_transaction_id = 11;
 }
 
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v3/mint.proto.dot.xs.svg)

--- a/proto/cmp/services/cancellation/v1/accept.proto
+++ b/proto/cmp/services/cancellation/v1/accept.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package cmp.services.cancellation.v1;
 
 import "cmp/types/v1/common.proto";
+import "cmp/types/v3/evm_transaction.proto";
 import "cmp/types/v3/price.proto";
 
 // Request for cancellation acceptance
@@ -33,5 +34,5 @@ message AcceptCancellationResponse {
   // 1. Prove the exact time of acceptance
   // 2. Validate the accepted refund amount
   // 3. Prevent disputes about acceptance terms
-  string transaction_id = 2;
+  cmp.types.v3.EVMTransactionID transaction_id = 2;
 }

--- a/proto/cmp/services/cancellation/v1/accept_counter.proto
+++ b/proto/cmp/services/cancellation/v1/accept_counter.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package cmp.services.cancellation.v1;
 
 import "cmp/types/v1/common.proto";
+import "cmp/types/v3/evm_transaction.proto";
 import "cmp/types/v3/price.proto";
 
 // Request for counter cancellation acceptance
@@ -25,5 +26,5 @@ message AcceptCounterCancellationResponse {
   // Transaction ID on-chain for the counter cancellation proposal acceptance. This
   // transaction proves the acceptance of the counter proposal on-chain to avoid
   // disputes.
-  string transaction_id = 2;
+  cmp.types.v3.EVMTransactionID transaction_id = 2;
 }

--- a/proto/cmp/services/cancellation/v1/counter.proto
+++ b/proto/cmp/services/cancellation/v1/counter.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package cmp.services.cancellation.v1;
 
 import "cmp/types/v1/common.proto";
+import "cmp/types/v3/evm_transaction.proto";
 import "cmp/types/v3/price.proto";
 
 // Request for countering a cancellation
@@ -27,5 +28,5 @@ message CounterCancellationResponse {
   // 1. Prove the exact time of the counter proposal
   // 2. Validate the counter refund amount
   // 3. Prevent disputes about counter terms
-  string transaction_id = 2;
+  cmp.types.v3.EVMTransactionID transaction_id = 2;
 }

--- a/proto/cmp/services/cancellation/v1/initiate.proto
+++ b/proto/cmp/services/cancellation/v1/initiate.proto
@@ -4,6 +4,7 @@ package cmp.services.cancellation.v1;
 
 import "cmp/services/cancellation/v1/reason.proto";
 import "cmp/types/v1/common.proto";
+import "cmp/types/v3/evm_transaction.proto";
 import "cmp/types/v3/price.proto";
 
 message InitiateCancellationRequest {
@@ -31,5 +32,5 @@ message InitiateCancellationResponse {
   // 1. Prove the exact time of initiation of the cancellation proposal
   // 2. Validate the refund amount
   // 3. Prevent disputes about the cancellation terms
-  string transaction_id = 2;
+  cmp.types.v3.EVMTransactionID transaction_id = 2;
 }

--- a/proto/cmp/services/cancellation/v1/reject.proto
+++ b/proto/cmp/services/cancellation/v1/reject.proto
@@ -4,6 +4,7 @@ package cmp.services.cancellation.v1;
 
 import "cmp/services/cancellation/v1/reason.proto";
 import "cmp/types/v1/common.proto";
+import "cmp/types/v3/evm_transaction.proto";
 
 // Request for cancellation rejection
 message RejectCancellationRequest {
@@ -28,5 +29,5 @@ message RejectCancellationResponse {
   // 1. Prove the exact time of the rejection
   // 2. Validate the rejection reason
   // 3. Prevent disputes about the cancellation
-  string transaction_id = 2;
+  cmp.types.v3.EVMTransactionID transaction_id = 2;
 }

--- a/proto/cmp/services/cancellation/v1/withdraw.proto
+++ b/proto/cmp/services/cancellation/v1/withdraw.proto
@@ -4,6 +4,7 @@ package cmp.services.cancellation.v1;
 
 import "cmp/services/cancellation/v1/reason.proto";
 import "cmp/types/v1/common.proto";
+import "cmp/types/v3/evm_transaction.proto";
 
 // Request for withdrawal of an active cancellation proposal
 message WithdrawCancellationRequest {
@@ -28,5 +29,5 @@ message WithdrawCancellationResponse {
   // 1. Prove the exact time of withdrawal
   // 2. Validate the accepted refund amount
   // 3. Prevent disputes about acceptance terms
-  string transaction_id = 2;
+  cmp.types.v3.EVMTransactionID transaction_id = 2;
 }

--- a/proto/cmp/services/claim/v1/claim_types.proto
+++ b/proto/cmp/services/claim/v1/claim_types.proto
@@ -5,6 +5,7 @@ package cmp.services.claim.v1;
 import "cmp/services/insurance/v2/search_result_types.proto";
 import "cmp/types/v1/date.proto";
 import "cmp/types/v3/company.proto";
+import "cmp/types/v3/evm_transaction.proto";
 import "cmp/types/v3/file.proto";
 import "cmp/types/v3/payment.proto";
 import "cmp/types/v3/price.proto";
@@ -185,7 +186,10 @@ message ClaimMessageResponse {
 // Claim Pay-Out Transaction
 message PayOutTransaction {
   // Transaction ID
-  string transaction_id = 1;
+  //
+  // FIXME: This looks like it's intended to be a string so it can be used for both
+  // on-chain and off-chain transactions. Should we use a oneof?
+  cmp.types.v3.EVMTransactionID transaction_id = 1;
 
   // Transaction Type. It can be Bank transfer, Crypto transfer, Credit card, ... etc
   cmp.types.v3.PaymentType transaction_type = 2;

--- a/proto/cmp/services/notification/v2/notify.proto
+++ b/proto/cmp/services/notification/v2/notify.proto
@@ -4,6 +4,7 @@ package cmp.services.notification.v2;
 
 import "cmp/services/cancellation/v1/reason.proto";
 import "cmp/types/v1/uuid.proto";
+import "cmp/types/v3/evm_transaction.proto";
 import "google/protobuf/empty.proto";
 
 // Notification service for different events that the partner should be notified about
@@ -31,7 +32,7 @@ service NotificationService {
 // ```
 message TokenBought {
   uint64 token_id = 1;
-  string tx_id = 2;
+  cmp.types.v3.EVMTransactionID tx_id = 2;
   cmp.types.v1.UUID mint_id = 3;
 }
 
@@ -42,7 +43,7 @@ message TokenBought {
 // ```
 message TokenExpired {
   uint64 token_id = 1;
-  string tx_id = 2;
+  cmp.types.v3.EVMTransactionID tx_id = 2;
   cmp.types.v1.UUID mint_id = 3;
 }
 
@@ -56,7 +57,7 @@ message CancellationPending {
   string proposed_by = 2;
   uint64 refund_amount = 3;
   cmp.services.cancellation.v1.CancellationReason reason = 4;
-  string tx_id = 5;
+  cmp.types.v3.EVMTransactionID tx_id = 5;
 }
 
 // Related on-chain event:
@@ -68,7 +69,7 @@ message CancellationAccepted {
   uint64 token_id = 1;
   string accepted_by = 2;
   uint64 refund_amount = 3;
-  string tx_id = 4;
+  cmp.types.v3.EVMTransactionID tx_id = 4;
 }
 
 // Related on-chain event:
@@ -80,7 +81,7 @@ message CancellationAcceptedByTheOwner {
   uint64 token_id = 1;
   string accepted_by = 2;
   uint64 refund_amount = 3;
-  string tx_id = 4;
+  cmp.types.v3.EVMTransactionID tx_id = 4;
 }
 
 // Related on-chain event:
@@ -92,7 +93,7 @@ message CancellationCountered {
   uint64 token_id = 1;
   string countered_by = 2;
   uint64 new_refund_amount = 3;
-  string tx_id = 4;
+  cmp.types.v3.EVMTransactionID tx_id = 4;
 }
 
 // Related on-chain event:
@@ -104,7 +105,7 @@ message CancellationWithdrawn {
   uint64 token_id = 1;
   string cancelled_by = 2;
   cmp.services.cancellation.v1.WithdrawalReason reason = 3;
-  string tx_id = 4;
+  cmp.types.v3.EVMTransactionID tx_id = 4;
 }
 
 // Related on-chain event:
@@ -116,5 +117,5 @@ message CancellationRejected {
   uint64 token_id = 1;
   string rejected_by = 2;
   cmp.services.cancellation.v1.RejectionReason reason = 3;
-  string tx_id = 4;
+  cmp.types.v3.EVMTransactionID tx_id = 4;
 }

--- a/proto/cmp/services/partner/v3/partner_configuration.proto
+++ b/proto/cmp/services/partner/v3/partner_configuration.proto
@@ -1,0 +1,49 @@
+syntax = "proto3";
+
+package cmp.services.partner.v3;
+
+import "cmp/types/v3/partner.proto";
+
+// Partner Configuration message type
+//
+// This message type represents the partner configuration on T-Chain (not
+// implemented yet)
+message PartnerConfiguration {
+  // List of partners from the on-chain Partner Configuration
+  repeated cmp.types.v3.Partner partners = 1;
+}
+
+message GetPartnerConfigurationRequest {
+  // Only respond with updated partners after this block height.
+  int32 block_height = 2;
+
+  // Partner wallet addresses. Response is returned with only partners that have
+  // these addresses.
+  repeated string partner_addresses = 3;
+}
+
+message GetPartnerConfigurationResponse {
+  // Partner configuration
+  cmp.services.partner.v3.PartnerConfiguration partner_configuration = 1;
+
+  // Current block height. Distributors can keep this info for later reference.
+  int32 current_block_height = 2;
+}
+
+// Get Partner Configuration Service
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v2/partner_configuration.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v2/partner_configuration.proto.dot.svg)
+//
+/// @custom:cmp-service type:product routing:local on-chain:true
+service GetPartnerConfigurationService {
+  // #### GetPartnerConfiguration
+  //
+  // Takes `GetPartnerConfigurationRequest` which contains optional block height and
+  // partner wallet addresses and returns `GetPartnerConfigurationResponse` which
+  // contains the current block height and the`PartnerConfiguration` for the given
+  // addresses (if any, returns all if none is provided) and only if the data is
+  // changed after the provided block height.
+  rpc GetPartnerConfiguration(GetPartnerConfigurationRequest) returns (GetPartnerConfigurationResponse);
+}

--- a/proto/cmp/services/partner/v3/partner_configuration.proto
+++ b/proto/cmp/services/partner/v3/partner_configuration.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package cmp.services.partner.v3;
 
+import "cmp/types/v3/evm_address.proto";
 import "cmp/types/v3/partner.proto";
 
 // Partner Configuration message type
@@ -19,7 +20,7 @@ message GetPartnerConfigurationRequest {
 
   // Partner wallet addresses. Response is returned with only partners that have
   // these addresses.
-  repeated string partner_addresses = 3;
+  repeated cmp.types.v3.EVMAddress partner_addresses = 3;
 }
 
 message GetPartnerConfigurationResponse {

--- a/proto/cmp/types/v3/currency.proto
+++ b/proto/cmp/types/v3/currency.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package cmp.types.v3;
 
-import "cmp/types/v2/token.proto";
+import "cmp/types/v3/token.proto";
 import "google/protobuf/empty.proto";
 
 // See extensive explanation at Price in price.proto
@@ -10,7 +10,7 @@ message Currency {
   oneof currency {
     cmp.types.v3.IsoCurrency iso_currency = 1;
 
-    cmp.types.v2.TokenCurrency token_currency = 2;
+    cmp.types.v3.TokenCurrency token_currency = 2;
 
     google.protobuf.Empty native_token = 3;
   }

--- a/proto/cmp/types/v3/evm_address.proto
+++ b/proto/cmp/types/v3/evm_address.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package cmp.types.v3;
+
+// Address type that represents an EVM address in hex format
+//
+// Example: "0x1234567890abcdef1234567890abcdef12345678"
+message EVMAddress {
+  string address = 1;
+}

--- a/proto/cmp/types/v3/evm_transaction.proto
+++ b/proto/cmp/types/v3/evm_transaction.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package cmp.types.v3;
+
+// This represents an EVM transaction ID in hex format
+//
+// Example: "0xeb8d83e82ff50b27ab9287cd84e1b55a39b30377e68203fb74837aa35c489924"
+message EVMTransactionID {
+  string hash = 1;
+}

--- a/proto/cmp/types/v3/partner.proto
+++ b/proto/cmp/types/v3/partner.proto
@@ -1,0 +1,158 @@
+syntax = "proto3";
+
+package cmp.types.v3;
+
+import "cmp/types/v1/wallet.proto";
+import "cmp/types/v3/token.proto";
+
+// ### Partner message type
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/partner.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/partner.proto.dot.svg)
+message Partner {
+  // Short name of the partner. Ex: Chain4Travel
+  string short_name = 1;
+
+  // Legal name of the partner. Ex: Chain4Travel AG
+  string legal_name = 2;
+
+  // Business description
+  string business_description = 3;
+
+  // Domain for the partner
+  //
+  // Ex: chain4travel.com
+  //
+  // Provider should create two DNS records for their address to verify they own
+  // the `partner_wallet_address` below. Two records should be for public key and
+  // the corresponding address.
+  //
+  // Example DNS TXT Records:
+  // `@   IN  TXT  "camino-t-addr=T-camino1tdkgjhfjq8z4glnvu8davxvdm66jx55tfr6qnz"  TTL 3600`
+  // `@   IN  TXT  "camino-pubkey=043134d4b70236e59f99ae9e6ed9d1d512bacfa83506c9371ff4e372b7837844d82b1c56d81d04a23e25b18ff3f7eb531a5ef17df3bf5730b29e13f854a65b4651"  TTL 3600`
+  //
+  // FIXME: Need review here!
+  string domain = 4;
+
+  // Supported tokens for payment (on-chain). If a TokenCurrency is specified, this
+  // then means that on-chain payment is supported.
+  repeated cmp.types.v3.TokenCurrency on_chain_currencies = 5;
+
+  // Off chain payment support
+  bool off_chain_payment_supported = 6;
+
+  // Supported services
+  repeated cmp.types.v3.PartnerService services = 7;
+
+  // Partner addresses of the messenger bots
+  repeated cmp.types.v1.WalletAddress addresses = 8;
+
+  // Partner's consortium member wallet address. This address should be the one who
+  // creates the entry in Partner Configuration on the chain.
+  cmp.types.v1.WalletAddress partner_wallet_address = 9;
+}
+
+// Partner Service
+//
+// Message representing a service sold by a partner.
+message PartnerService {
+  // Name of the service.
+  //
+  // FIXME: Should we include package name also here? If not, how should the bot
+  // supposed to find the message? If yes, package name also includes the version
+  // which means partner will need to update supported services with every new
+  // version.
+  //
+  // Ex: "cmp.services.accommodation.v1.AccommodationSearchService"
+  string service_name = 1;
+
+  // Response of the service.
+  //
+  // Ex: "cmp.services.accommodation.v1.AccommodationSearchResponse"
+  //
+  // FIXME: Do we need this? One can check the service definition and see the
+  // response message type.
+  string response_name = 2;
+
+  // Result field
+  //
+  // Ex: "options" representing the field at
+  // "cmp.services.accommodation.v1.AccommodationSearchResponse.options" which
+  // is a SearchOption type
+  string result_field = 3;
+
+  // Result Type.
+  //
+  // Ex: ResultType.RESULT_TYPE_DISCRETE
+  cmp.types.v3.ResultType result_type = 4;
+
+  // Default bundled price for the service
+  cmp.types.v3.BundledPrice bundled_price = 5;
+
+  // Exclusive bundled prices for specific addresses.
+  //
+  // This field should be a serialized proto message of `CustomBundledPrice` type.
+  // The field's scalar type is `bytes` on purpose, so it can be encrypted if it's
+  // desired.
+  repeated bytes custom_bundled_prices = 6;
+}
+
+// Custom Bundle Price
+//
+// This message encapsulates `BundledPrice` message to be used for a custom price
+// per buyer. If it's required, this message can be encrypted before adding it to
+// the `PartnerService` message type.
+message CustomBundledPrice {
+  // Address of the wallet that the bundled price below is valid for.
+  string address = 1;
+
+  // Bundled price that is exclusive to the wallet address above.
+  cmp.types.v3.BundledPrice bundled_price = 2;
+}
+
+// Bundled Price
+//
+// Message representing a bundled price of a service.
+message BundledPrice {
+  // Bundle size.
+  //
+  // Example for a chat bot: 1
+  //
+  // Example for SearchOptions: 100
+  int32 results_per_bundle = 1;
+
+  // Bundle Unit, represents the bundle's unit. For example for search results it
+  // should be `BundleUnit.BUNDLE_UNIT_COUNT` or for AI Chat bot results it can be
+  // `BundleUnit.BUNDLE_UNIT_BYTES` or `BundleUnit.BUNDLE_UNIT_KILOBYTES`
+  cmp.types.v3.BundleUnit results_per_bundle_unit = 2;
+
+  // Price per bundle, in nCAMs
+  //
+  // Ex: 100
+  int64 price_per_bundle = 3;
+}
+
+// Bundle unit message type
+enum BundleUnit {
+  BUNDLE_UNIT_UNSPECIFIED = 0;
+  BUNDLE_UNIT_COUNT = 1;
+  BUNDLE_UNIT_BYTES = 2;
+  BUNDLE_UNIT_KILOBYTES = 3;
+  BUNDLE_UNIT_MEGABYTES = 4;
+  // BUNDLE_UNIT_CHARACTERS = 5; // Characters, words??
+}
+
+enum ResultType {
+  RESULT_TYPE_UNSPECIFIED = 0;
+
+  // Objects countable with integers, like the SearchOption of an
+  // `AccommodationSearchResponse`
+  RESULT_TYPE_DISCRETE = 1;
+
+  // Continous data types like strings.
+  //
+  // Ex: A response from a chat bot can be 100 chars long or 20000 chars long. Or in
+  // bytes or kilobytes for some binary data.
+  RESULT_TYPE_NON_DISCRETE = 2;
+}

--- a/proto/cmp/types/v3/token.proto
+++ b/proto/cmp/types/v3/token.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package cmp.types.v3;
+
+import "cmp/types/v3/evm_address.proto";
+
+// Token Reference
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v3/token.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v3/token.proto.dot.svg)
+message TokenCurrency {
+  cmp.types.v3.EVMAddress contract_address = 1;
+}
+
+// Booking token that represents to access to the service
+message Token {
+  // Contract address of the smart contract or the address of natively implemented
+  // asset on-chain.
+  cmp.types.v3.EVMAddress contract = 1;
+
+  // Token ID
+  uint64 token_id = 2;
+}


### PR DESCRIPTION
This PR:
- adds `EVMAddress` and `EVMTransactionID` types, so we can use them later for input validation
- updates the `string` txn and addr field to these new fields
- run dependency checker script with fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added structured EVM transaction and address types across multiple services
  - Introduced partner configuration service
  - Added new token and currency type definitions

- **Improvements**
  - Enhanced type safety for transaction and address handling
  - Updated import paths for token and currency types
  - Standardized transaction and partner-related data models

- **Technical Updates**
  - Updated protocol buffer definitions for multiple services
  - Introduced new message types for EVM transactions and addresses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->