### PR TITLE
Add last_modified to TripBasic

### DIFF
--- a/proto/cmp/services/transport/v3/trip_types.proto
+++ b/proto/cmp/services/transport/v3/trip_types.proto
@@ -51,7 +51,7 @@ message TripBasic {
   // Timestamps may be used for both off-chain and on-chain operations.
   // For on-chain operations, only seconds are supported, and nanoseconds
   // will be ignored.
-	google.protobuf.Timestamp last_modified = 3;
+  google.protobuf.Timestamp last_modified = 3;
 }
 
 // A segment of a trip

--- a/proto/cmp/services/transport/v3/trip_types.proto
+++ b/proto/cmp/services/transport/v3/trip_types.proto
@@ -47,6 +47,11 @@ message TripBasic {
   //
   // Departure and Arrival dates and times can be derived from the first and last segments
   repeated cmp.services.transport.v3.Segment segments = 2;
+
+  // Timestamps may be used for both off-chain and on-chain operations.
+	// For on-chain operations, only seconds are supported, and nanoseconds
+	// will be ignored.
+	google.protobuf.Timestamp last_modified = 3;
 }
 
 // A segment of a trip

--- a/proto/cmp/services/transport/v3/trip_types.proto
+++ b/proto/cmp/services/transport/v3/trip_types.proto
@@ -49,8 +49,8 @@ message TripBasic {
   repeated cmp.services.transport.v3.Segment segments = 2;
 
   // Timestamps may be used for both off-chain and on-chain operations.
-	// For on-chain operations, only seconds are supported, and nanoseconds
-	// will be ignored.
+  // For on-chain operations, only seconds are supported, and nanoseconds
+  // will be ignored.
 	google.protobuf.Timestamp last_modified = 3;
 }
 


### PR DESCRIPTION
There is **modified_after** in [Transportation Product List Request](https://buf.build/chain4travel/camino-messenger-protocol/docs/dev:cmp.services.transport.v3#cmp.services.transport.v3.TransportProductListRequest
), just like in [Accommodation Product List Request](https://buf.build/chain4travel/camino-messenger-protocol/docs/dev:cmp.services.accommodation.v3#cmp.services.accommodation.v3.AccommodationProductInfoRequest)
but unlike [Properties](https://buf.build/chain4travel/camino-messenger-protocol/docs/dev:cmp.services.accommodation.v3#cmp.services.accommodation.v3.Property), [TripBasic](https://buf.build/chain4travel/camino-messenger-protocol/docs/dev:cmp.services.transport.v3#cmp.services.transport.v3.TripBasic)  don't  seem to have **last_modified** field.

This PR adds the field so that **modified_after** in ProductListRequest can be used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a modification timestamp to trip records, allowing the system to accurately capture and display the last update time for each trip across various operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->