### PR TITLE
Improve location for TransitEvent and QueryTransitEvent

### DIFF
--- a/proto/cmp/services/transport/v3/search_query_types.proto
+++ b/proto/cmp/services/transport/v3/search_query_types.proto
@@ -50,5 +50,25 @@ message QueryTransitEvent {
   cmp.types.v1.Date date = 1;
 
   // Event location
-  cmp.types.v2.LocationCode location_code = 2;
+  cmp.services.transport.v3.QueryTransitEventLocation location = 2;
+}
+
+// Represents a departure or arrival event's location
+message QueryTransitEventLocation {
+  oneof location {
+    // A list of location codes or just one code.
+    cmp.types.v2.LocationCodes location_codes = 1;
+
+    // Single geographic point represented by two double fields.
+    cmp.types.v2.Coordinates location_coordinates = 2;
+
+    // Geo tree type, represented by Country, Region, and City_or_Resort.
+    cmp.types.v2.GeoTree location_geo_tree = 3;
+
+    // Geo circle. Represented by a coordinate and a distance for radius
+    cmp.types.v2.GeoCircle location_geo_circle = 4;
+
+    // Geo polygon. Represented by a list of coordinate points.
+    cmp.types.v2.GeoPolygon location_geo_polygon = 5;
+  }
 }

--- a/proto/cmp/services/transport/v3/trip_types.proto
+++ b/proto/cmp/services/transport/v3/trip_types.proto
@@ -149,5 +149,16 @@ message TransitEvent {
   google.protobuf.Timestamp date_time = 1;
 
   // Event location
-  cmp.types.v2.LocationCode location_code = 2;
+  cmp.services.transport.v3.TransitEventLocation location = 2;
+}
+
+// Represents a departure or arrival event's location
+message TransitEventLocation {
+  oneof location {
+    // A location code.
+    cmp.types.v2.LocationCode location_code = 1;
+
+    // Single geographic point represented by two double fields.
+    cmp.types.v2.Coordinates location_coordinates = 2;
+  }
 }


### PR DESCRIPTION
This PR updates `TransitEvent` and `QueryTransitEvent` message types in `transport` by adding new location types with extended options for location types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced transit event location representation to support multiple input formats.
  - Users can now specify event locations using various options such as codes, geographic coordinates, structured geo data, circles, or polygons for a more flexible search experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->