### PR TITLE
Cleaning up the search headers 

### DIFF
--- a/proto/cmp/services/accommodation/v4/search.proto
+++ b/proto/cmp/services/accommodation/v4/search.proto
@@ -103,8 +103,8 @@ message AccommodationSearchResponse {
   // address.
   cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
 
-  // Search response metadata
-  cmp.types.v4.SearchResponseMetadata metadata = 2 [(buf.validate.field).required = true];
+  // Search_id to be used in subsequent requests like the "Validation Request".
+  cmp.types.v4.UUID search_id = 2 [(buf.validate.field).required = true];
 
   // Unique combinations of bookable search results, like property,
   repeated cmp.services.accommodation.v4.AccommodationSearchResult results = 3 [(buf.validate.field).repeated = {

--- a/proto/cmp/services/accommodation/v4/search.proto
+++ b/proto/cmp/services/accommodation/v4/search.proto
@@ -76,19 +76,16 @@ message AccommodationSearchRequest {
   // address
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];
 
-  // Search request metadata
-  cmp.types.v4.SearchRequestMetadata metadata = 2 [(buf.validate.field).required = true];
-
   // Generic search parameters Ex: Inclusion of OnRequest options and inclusion of
   // only the cheapest or all options.
   // In the search parameters multiple filters can be applied for upfront filtering
   // of the search results to for example to only include hotels that are less than
   // one kilometer from the beach, have a kids club and offer an a la carte restaurant
-  cmp.types.v4.SearchParameters search_parameters = 3 [(buf.validate.field).required = true];
+  cmp.types.v4.SearchParameters search_parameters = 2 [(buf.validate.field).required = true];
 
   // This field represents a list of search queries that can be used to create
   // multiroom multi location searches.
-  repeated cmp.services.accommodation.v4.AccommodationSearchQuery queries = 4 [(buf.validate.field).repeated = {
+  repeated cmp.services.accommodation.v4.AccommodationSearchQuery queries = 3 [(buf.validate.field).repeated = {
     min_items: 1
     max_items: 10
   }];

--- a/proto/cmp/services/accommodation/v4/search.proto
+++ b/proto/cmp/services/accommodation/v4/search.proto
@@ -18,6 +18,7 @@ import "cmp/services/accommodation/v4/search_result_types.proto";
 import "cmp/types/v4/common.proto";
 import "cmp/types/v4/search.proto";
 import "cmp/types/v4/traveller.proto";
+import "cmp/types/v4/uuid.proto";
 
 // The `Accommodation Search Request` message type facilitates the request for
 // accommodations like hotel and holiday home searches within the platform. In the

--- a/proto/cmp/services/activity/v4/search.proto
+++ b/proto/cmp/services/activity/v4/search.proto
@@ -52,26 +52,23 @@ message ActivitySearchRequest {
   // address.
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];
 
-  // Search request metadata
-  cmp.types.v4.SearchRequestMetadata metadata = 2 [(buf.validate.field).required = true];
-
   // Generic search parameters
   //
   // Ex: Inclusion of OnRequest options, inclusion of only the cheapest or all
   // options, setting the market, language, currency, sorting and filters etc.
-  cmp.types.v4.SearchParameters search_parameters = 3 [(buf.validate.field).required = true];
+  cmp.types.v4.SearchParameters search_parameters = 2 [(buf.validate.field).required = true];
 
   // Activity specific search parameters
   //
   // Here we set for example a list of activity product codes that we want to search
   // for, set min or mar duration or price.
-  cmp.services.activity.v4.ActivitySearchParameters search_parameters_activity = 4;
+  cmp.services.activity.v4.ActivitySearchParameters search_parameters_activity = 3;
 
   // Travel period
-  cmp.types.v4.TravelPeriod travel_period = 5 [(buf.validate.field).required = true];
+  cmp.types.v4.TravelPeriod travel_period = 4 [(buf.validate.field).required = true];
 
   // Travellers
-  repeated cmp.types.v4.BasicTraveller travellers = 6 [(buf.validate.field).repeated = {
+  repeated cmp.types.v4.BasicTraveller travellers = 5 [(buf.validate.field).repeated = {
     min_items: 1
     max_items: 15
   }];
@@ -89,19 +86,19 @@ message ActivitySearchRequest {
   oneof source_location {
     // The code and code type of a stay location the provider will be able to process
     // Ex. GiataID
-    cmp.types.v4.LocationCodes source_location_codes = 7;
+    cmp.types.v4.LocationCodes source_location_codes = 6;
 
     // Single geographic point represented by two double fields.
-    cmp.types.v4.Coordinates source_location_coordinates = 8;
+    cmp.types.v4.Coordinates source_location_coordinates = 7;
 
     // Geo tree type, represented by Country, Region, and City_or_Resort.
-    cmp.types.v4.GeoTree source_location_geo_tree = 9;
+    cmp.types.v4.GeoTree source_location_geo_tree = 8;
 
     // Geo circle. Represented by a coordinate and a distance for radius
-    cmp.types.v4.GeoCircle source_location_geo_circle = 10;
+    cmp.types.v4.GeoCircle source_location_geo_circle = 9;
 
     // Geo polygon. Represented by a list of coordinate points.
-    cmp.types.v4.GeoPolygon source_location_geo_polygon = 11;
+    cmp.types.v4.GeoPolygon source_location_geo_polygon = 10;
   }
 
   // For search, set only one of the field at once. Service location specifies the
@@ -114,19 +111,19 @@ message ActivitySearchRequest {
     // The code and code type of a stay location the distributor will be able to
     // process. Ex. Google Place ID, Foursquare fsq_id, OpenStreetMap Ref, Here ID or
     // any other agreed code type.
-    cmp.types.v4.LocationCodes service_location_codes = 12;
+    cmp.types.v4.LocationCodes service_location_codes = 11;
 
     // Single geographic point represented by two double fields.
-    cmp.types.v4.Coordinates service_location_coordinates = 13;
+    cmp.types.v4.Coordinates service_location_coordinates = 12;
 
     // Geo tree type, represented by Country, Region, and City_or_Resort.
-    cmp.types.v4.GeoTree service_location_geo_tree = 14;
+    cmp.types.v4.GeoTree service_location_geo_tree = 13;
 
     // Geo circle. Represented by a coordinate and a distance for radius
-    cmp.types.v4.GeoCircle service_location_geo_circle = 15;
+    cmp.types.v4.GeoCircle service_location_geo_circle = 14;
 
     // Geo polygon. Represented by a list of coordinate points.
-    cmp.types.v4.GeoPolygon service_location_geo_polygon = 16;
+    cmp.types.v4.GeoPolygon service_location_geo_polygon = 15;
   }
 }
 

--- a/proto/cmp/services/activity/v4/search.proto
+++ b/proto/cmp/services/activity/v4/search.proto
@@ -45,6 +45,7 @@ import "cmp/types/v4/location.proto";
 import "cmp/types/v4/search.proto";
 import "cmp/types/v4/travel_period.proto";
 import "cmp/types/v4/traveller.proto";
+import "cmp/types/v4/uuid.proto";
 
 // Search request for Activities
 message ActivitySearchRequest {

--- a/proto/cmp/services/activity/v4/search.proto
+++ b/proto/cmp/services/activity/v4/search.proto
@@ -132,11 +132,8 @@ message ActivitySearchResponse {
   // address.
   cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
 
-  // Search response metadata
-  //
-  // The most important field is the search_id, which is a UUID that needs to be
-  // carried through to the validate request.
-  cmp.types.v4.SearchResponseMetadata metadata = 2 [(buf.validate.field).required = true];
+  // Search_id to be used in subsequent requests like the "Validation Request".
+  cmp.types.v4.UUID search_id = 2 [(buf.validate.field).required = true];
 
   // Unique combinations of bookable search results, each identified by a result_id
   // that needs to be carried through to the validate request.

--- a/proto/cmp/services/book/v4/mint.proto
+++ b/proto/cmp/services/book/v4/mint.proto
@@ -21,18 +21,15 @@ message MintRequest {
   // This must be a UUID according to RFC 4122
   cmp.types.v4.UUID validation_id = 2 [(buf.validate.field).required = true];
 
-  // FIXME: Move this into the header section
-  string external_session_id = 3 [(buf.validate.field).string.max_bytes = 512];
+  // FIXME: Do we need this here in the mint request? It's already specified in the search.
+  cmp.types.v1.Language language = 3;
 
   // FIXME: Do we need this here in the mint request? It's already specified in the search.
-  cmp.types.v1.Language language = 4;
+  string market = 4 [(buf.validate.field).string.max_bytes = 512];
 
-  // FIXME: Do we need this here in the mint request? It's already specified in the search.
-  string market = 5 [(buf.validate.field).string.max_bytes = 512];
+  string booking_reference = 5 [(buf.validate.field).string.max_bytes = 512];
 
-  string booking_reference = 6 [(buf.validate.field).string.max_bytes = 512];
-
-  repeated cmp.types.v4.ExtensiveTraveller travellers = 7 [(buf.validate.field).repeated = {
+  repeated cmp.types.v4.ExtensiveTraveller travellers = 6 [(buf.validate.field).repeated = {
     min_items: 1
     max_items: 100
   }];
@@ -40,26 +37,26 @@ message MintRequest {
   // The comments field is meant to pass noncommittal remarks entered by the
   // end-consumer about the service reservation,  like "non-smoking room please",
   // "top floor room please".
-  string comment = 8 [(buf.validate.field).string.max_bytes = 512];
+  string comment = 7 [(buf.validate.field).string.max_bytes = 512];
 
   // Public keys that will be used to encrypt the private booking data
   // TODO: When we implement the private booking data, we need to set min_items to 1.
-  repeated cmp.types.v4.PublicKey public_keys = 9 [(buf.validate.field).repeated = {
+  repeated cmp.types.v4.PublicKey public_keys = 8 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100
   }];
 
   // Buyer's address. Only this address should be allowed to buy the `BookingToken`
   // on chain.
-  cmp.types.v4.EVMAddress buyer_address = 10 [(buf.validate.field).required = true];
+  cmp.types.v4.EVMAddress buyer_address = 9 [(buf.validate.field).required = true];
 
   // This field is only relevant for off chain virtual credit card payments.
-  cmp.types.v4.AdditionalPaymentInfo additional_payment_info = 11;
+  cmp.types.v4.AdditionalPaymentInfo additional_payment_info = 10;
 
   // Expected BookingToken price. This price should be used by the bot to verify
   // that the CMAccount of the distributor has enough funds to buy the minted
   // BookingToken.
-  cmp.types.v4.Price expected_price = 12 [(buf.validate.field).required = true];
+  cmp.types.v4.Price expected_price = 11 [(buf.validate.field).required = true];
 }
 
 message MintResponse {

--- a/proto/cmp/services/insurance/v3/search.proto
+++ b/proto/cmp/services/insurance/v3/search.proto
@@ -22,6 +22,7 @@ import "cmp/services/insurance/v3/search_result_types.proto";
 import "cmp/types/v4/common.proto";
 import "cmp/types/v4/search.proto";
 import "cmp/types/v4/traveller.proto";
+import "cmp/types/v4/uuid.proto";
 
 // InsuranceSearchRequest
 //
@@ -41,15 +42,12 @@ message InsuranceSearchRequest {
   // address
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];
 
-  // Search request metadata
-  cmp.types.v4.SearchRequestMetadata metadata = 2 [(buf.validate.field).required = true];
-
   // Generic search parameters Ex: Inclusion of OnRequest options and inclusion of
   // only the cheapest or all options.
   // In the search parameters multiple filters can be applied for upfront filtering
   // of the search results to for example to only include hotels that are less than
   // one kilometer from the beach, have a kids club and offer an a la carte restaurant
-  cmp.types.v4.SearchParameters search_parameters = 3 [(buf.validate.field).required = true];
+  cmp.types.v4.SearchParameters search_parameters = 2 [(buf.validate.field).required = true];
 
   // This field represents a list of search queries that can be used to create
   // a request that covers multiple bookings, travellers that have a different
@@ -63,7 +61,7 @@ message InsuranceSearchRequest {
   // Instead of adding multiple product families into multiple queries, it is
   // recommended to split them into multiple requests so that they can be
   // processed in parallel.
-  repeated cmp.services.insurance.v3.InsuranceSearchQuery queries = 4 [(buf.validate.field).repeated = {
+  repeated cmp.services.insurance.v3.InsuranceSearchQuery queries = 3 [(buf.validate.field).repeated = {
     min_items: 1
     max_items: 10
   }];
@@ -81,8 +79,8 @@ message InsuranceSearchResponse {
   // address.
   cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
 
-  // Search response metadata
-  cmp.types.v4.SearchResponseMetadata metadata = 2 [(buf.validate.field).required = true];
+  // Search_id to be used in subsequent requests like the "Validation Request".
+  cmp.types.v4.UUID search_id = 2 [(buf.validate.field).required = true];
 
   // Unique combinations of bookable search results, like property,
   repeated cmp.services.insurance.v3.InsuranceSearchResult results = 3 [(buf.validate.field).repeated = {

--- a/proto/cmp/services/transport/v4/search.proto
+++ b/proto/cmp/services/transport/v4/search.proto
@@ -25,17 +25,13 @@ message TransportSearchRequest {
   // address
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];
 
-  // Search request metadata
-  cmp.types.v4.SearchRequestMetadata metadata = 2 [(buf.validate.field).required = true];
-
   // Generic search parameters
-  //
   // Ex: Inclusion of OnRequest options and inclusion of only the cheapest or all
   // options.
-  cmp.types.v4.SearchParameters search_parameters = 3 [(buf.validate.field).required = true];
+  cmp.types.v4.SearchParameters search_parameters = 2 [(buf.validate.field).required = true];
 
   // Multiple search queries for this search request
-  repeated cmp.services.transport.v4.TransportSearchQuery queries = 4 [(buf.validate.field).repeated = {
+  repeated cmp.services.transport.v4.TransportSearchQuery queries = 3 [(buf.validate.field).repeated = {
     min_items: 1
     max_items: 10
   }];

--- a/proto/cmp/services/transport/v4/search.proto
+++ b/proto/cmp/services/transport/v4/search.proto
@@ -18,6 +18,7 @@ import "cmp/types/v1/content_source.proto";
 import "cmp/types/v4/common.proto";
 import "cmp/types/v4/search.proto";
 import "cmp/types/v4/traveller.proto";
+import "cmp/types/v4/uuid.proto";
 
 // Transport Search Request
 message TransportSearchRequest {

--- a/proto/cmp/services/transport/v4/search.proto
+++ b/proto/cmp/services/transport/v4/search.proto
@@ -42,8 +42,8 @@ message TransportSearchResponse {
   // address
   cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
 
-  // Search response metadata
-  cmp.types.v4.SearchResponseMetadata metadata = 2 [(buf.validate.field).required = true];
+  // Search_id to be used in subsequent requests like the "Validation Request".
+  cmp.types.v4.UUID search_id = 2 [(buf.validate.field).required = true];
 
   // Content source types for this search request.
   //

--- a/proto/cmp/types/v4/common.proto
+++ b/proto/cmp/types/v4/common.proto
@@ -59,7 +59,17 @@ message Header {
   // a specific user account on a blockchain-based system.
   cmp.types.v4.EVMAddress end_user_wallet_address = 2;
 
-  // FIXME: move external session id here from other messages
+  // An optional identifier for external sessions, aiding in tracking and continuity
+  // across sessions.
+  // This is specified by the initiating system (e.g., a partner plugin)
+  // and can be used to identify not only the request/response pair but also
+  // subsequent interactions related to the same business case.
+  // This field if given in the request header needs to be mirrored in the
+  // response header to maintain session context.
+  string external_session_id = 3 [(buf.validate.field).string = {
+    min_len: 0
+    max_bytes: 512
+  }];
 }
 
 // Version represents a semantic version (Major.Minor.Patch).

--- a/proto/cmp/types/v4/search.proto
+++ b/proto/cmp/types/v4/search.proto
@@ -90,35 +90,9 @@ message SearchParameters {
   }];
 }
 
-// This message type is used in every search response to contain the response metadata
-message SearchResponseMetadata {
-  // Search_id to be used in the Validation Request. This must be a UUID according
-  // to RFC 4122
-  cmp.types.v4.UUID search_id = 1 [(buf.validate.field).required = true];
-
-  // Context for Inventory system concepts that need to be included in a search response,
-  // like an OwnerCode, PTC_OfferParameters, Tax codes, Disclosure RefID, etc. or a
-  // serialized combination of these codes.
-  //
-  // TODO: Is this needed? Clarify!
-  string context = 2 [(buf.validate.field).string = {
-    min_len: 0
-    max_bytes: 512
-  }];
-
-  // Supplier code from the Inventory System for this search response.
-  //
-  // TODO: Is this needed? Clarify!
-  string supplier_code = 3 [(buf.validate.field).string = {
-    min_len: 0
-    max_bytes: 512
-  }];
-}
-
 // Search identifier
 message SearchIdentifier {
-  // Search ID that is returned in the search response message in the `metadata``
-  // (`SearchResponseMetadata`) field.
+  // Search ID that is returned in the search response message
   cmp.types.v4.UUID search_id = 1 [(buf.validate.field).required = true];
 
   // Result ID that is returned by `result_id` field of the search result

--- a/proto/cmp/types/v4/search.proto
+++ b/proto/cmp/types/v4/search.proto
@@ -90,19 +90,6 @@ message SearchParameters {
   }];
 }
 
-// This message type is used in every search request to contain the request metadata
-message SearchRequestMetadata {
-  // Request unique identifier
-  cmp.types.v4.UUID request_id = 1 [(buf.validate.field).required = true];
-
-  // An identifier for external sessions, aiding in tracking and continuity across
-  // sessions.
-  string external_session_id = 2 [(buf.validate.field).string = {
-    min_len: 0
-    max_bytes: 512
-  }];
-}
-
 // This message type is used in every search response to contain the response metadata
 message SearchResponseMetadata {
   // Search_id to be used in the Validation Request. This must be a UUID according
@@ -126,9 +113,6 @@ message SearchResponseMetadata {
     min_len: 0
     max_bytes: 512
   }];
-
-  // Search request metadata that this response is generated for
-  cmp.types.v4.SearchRequestMetadata search_request_metadata = 4 [(buf.validate.field).required = true];
 }
 
 // Search identifier


### PR DESCRIPTION
The search request headers were cleaned up by removing the RequestID which doesn't make much sense as we already have a RequestID in the metadata on the transport level.
By moving the external_session_id into the general headers the SearchRequestHeader was empty and removed.

Similar to that the SearchResponseHeader contained 3 fields where 2 fields did not have a meaningful reason to exist. Therefore this was also removed and replaced directly with the search_id in the search responses.