### PR TITLE
Bump protovalidate to v1.0.0 in lock file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
       - "proto/**"
       - ".github/workflows/**"
       - "scripts/**"
+      - "buf.*"
     branches:
       - c4t
       - dev
@@ -17,6 +18,7 @@ on:
       - "proto/**"
       - ".github/workflows/**"
       - "scripts/**"
+      - "buf.*"
 
 jobs:
   # Run buf's lint to check for errros

--- a/buf.lock
+++ b/buf.lock
@@ -2,5 +2,5 @@
 version: v2
 deps:
   - name: buf.build/bufbuild/protovalidate
-    commit: 0409229c37804d6187ee0806eb4eebce
-    digest: b5:795db9d3a6e066dc61d99ac651fa7f136171869abe2211ca272dd84aada7bc4583b9508249fa5b61300a5b1fe8b6dbf6edbc088aa0345d1ccb9fff705e3d48e9
+    commit: 52f32327d4b045a79293a6ad4e7e1236
+    digest: b5:cbabc98d4b7b7b0447c9b15f68eeb8a7a44ef8516cb386ac5f66e7fd4062cd6723ed3f452ad8c384b851f79e33d26e7f8a94e2b807282b3def1cd966c7eace97


### PR DESCRIPTION
This PR bumps the version of protovalidate in the `buf.lock` file to the latest version. (v1.0.0)