### PR TITLE
TransportV4 review (Product/Supplier codes)

### DIFF
--- a/proto/cmp/services/transport/v4/search_parameters_types.proto
+++ b/proto/cmp/services/transport/v4/search_parameters_types.proto
@@ -14,46 +14,38 @@ import "cmp/types/v4/time.proto";
 //
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_parameters_types.proto.dot.svg)
 message TransportSearchParameters {
-  // Specify one or more type codes to be included in the search response
-  // Ex: code "EW" number "1234" of the type "IATA"
-  repeated cmp.types.v4.ProductCode product_codes = 1 [(buf.validate.field).repeated = {
-    min_items: 0
-    max_items: 100
-  }];
-
-  // Specify one or more supplier codes to be included in the search response
-  // These must match the supplier codes provided in the ProductList and
-  // ProductInfo messages
-  repeated cmp.types.v4.SupplierProductCode supplier_codes = 2 [(buf.validate.field).repeated = {
+  // Specify one or more trip supplier codes to be included in the search response
+  // These must match the supplier codes provided in the ProductListResponse
+  repeated cmp.types.v4.SupplierProductCode trip_supplier_codes = 1 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100
   }];
 
   // The minimum and maximum duration of a transport to be included in the search
   // response
-  cmp.types.v4.DurationRange duration_range = 3;
+  cmp.types.v4.DurationRange duration_range = 2;
 
   // The minimum price of a transport to be included in the search response
-  cmp.types.v4.PriceRange price_range = 4;
+  cmp.types.v4.PriceRange price_range = 3;
 
   // One or more brand codes or distribution channels for which assigned product is
   // to be included in the search response
-  repeated string brand_codes = 6;
+  repeated string brand_codes = 4;
 
   // The maximum number of segments a trip might be containing, if only a direct
   // flight, transfer, or train journey the maximum number of segments is set to
   // one.
-  uint32 max_segments = 7;
+  uint32 max_segments = 5;
 
   // Minimum departure time of the trip
-  cmp.types.v4.Time trip_min_departure_time = 8;
+  cmp.types.v4.Time trip_min_departure_time = 6;
 
   // Maximum departure time of the trip
-  cmp.types.v4.Time trip_max_departure_time = 9;
+  cmp.types.v4.Time trip_max_departure_time = 7;
 
   // Minimum arrival time of the trip
-  cmp.types.v4.Time trip_min_arrival_time = 10;
+  cmp.types.v4.Time trip_min_arrival_time = 8;
 
   // Maximum arrival time of the trip
-  cmp.types.v4.Time trip_max_arrival_time = 11;
+  cmp.types.v4.Time trip_max_arrival_time = 9;
 }

--- a/proto/cmp/services/transport/v4/trip_types.proto
+++ b/proto/cmp/services/transport/v4/trip_types.proto
@@ -149,20 +149,26 @@ message Segment {
   // that is operated by Transunion.
   string sub_supplier_code = 4 [(buf.validate.field).string.max_bytes = 512];
 
-  // Product Code and Number
-  //
-  // For flights we use the IATA or ICAO airline code in the code field and the
-  // flight number in the number field.
-  //
-  // For train some operators use a combination of a code and a number like
-  // Eurostar, but others just use a code or a number (SNCF).
-  //
-  // Transfers are often identified by just a product code servicing an area.
-  cmp.types.v4.ProductCode product_code = 5;
+  // For products which are globally identified by external providers like IATA,
+  // ICAO for flights, or other global identification systems the product_code
+  // is used. In case the product is only identified by a supplier specific code,
+  // the supplier_code field is used.
+  oneof product_identifier {
+    option (buf.validate.oneof).required = true; // One must be provided
+    // Product Code and Number
+    //
+    // For flights we use the IATA or ICAO airline code in the code field and the
+    // flight number in the number field.
+    //
+    // For train some operators use a combination of a code and a number like
+    // Eurostar, but others just use a code or a number (SNCF).
+    //
+    // Transfers are often identified by just a product code servicing an area.
+    cmp.types.v4.ProductCode product_code = 5;
 
-  // Supplier specific code, matching the supplier code in ProductList and ProductInfo
-  // messages
-  cmp.types.v4.SupplierProductCode supplier_code = 6 [(buf.validate.field).required = true];
+    // Supplier specific code, matching the supplier code in ProductListResponse
+    cmp.types.v4.SupplierProductCode supplier_code = 6;
+  }
 
   // Departure of this segment (sometimes also called origin)
   cmp.services.transport.v4.TransitEvent departure = 7 [(buf.validate.field).required = true];


### PR DESCRIPTION
Introduced a product identifier oneof in the segment for flights vs. trains/transfer. Removed the product code from the trip and renamed it in the search to trip_supplier_code.