### PR TITLE
Activity V4 Review

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,8 @@ jobs:
         run: scripts/diff_against_branch.sh
       - name: Buf Breaking Check # Run buf breaking against main label on buf.build
         run: scripts/buf-breaking.sh
+      - name: Verify diagrams
+        run: scripts/verify_diagram_links.sh
 
   # Check if the service tags are set correctly and create a summary for that
   analyze-service-tags:

--- a/proto/cmp/services/accommodation/v2/search_query_types.proto
+++ b/proto/cmp/services/accommodation/v2/search_query_types.proto
@@ -7,6 +7,11 @@ import "cmp/services/accommodation/v2/unit_types.proto";
 import "cmp/types/v1/travel_period.proto";
 import "cmp/types/v2/traveller.proto";
 
+// Accommodation Search Query
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search_query_types.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search_query_types.proto.dot.svg)
 message AccommodationSearchQuery {
   // Integer query ID, unique per search request
   int32 query_id = 1;

--- a/proto/cmp/services/accommodation/v3/search_query_types.proto
+++ b/proto/cmp/services/accommodation/v3/search_query_types.proto
@@ -7,6 +7,11 @@ import "cmp/services/accommodation/v3/unit_types.proto";
 import "cmp/types/v1/travel_period.proto";
 import "cmp/types/v3/traveller.proto";
 
+// Accommodation Search Query
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v3/search_query_types.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v3/search_query_types.proto.dot.svg)
 message AccommodationSearchQuery {
   // Integer query ID, unique per search request
   int32 query_id = 1;

--- a/proto/cmp/services/accommodation/v4/search_parameters_types.proto
+++ b/proto/cmp/services/accommodation/v4/search_parameters_types.proto
@@ -15,10 +15,9 @@ import "cmp/types/v4/rate.proto";
 // While all fields in this message are optional at the message level, each supplier
 // may define their own minimum set of required filter parameters.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search_parameters_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v4/search_parameters_types.proto.dot.xs.svg)
 //
-// [Open Message
-// Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v2/search_parameters_types.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v4/search_parameters_types.proto.dot.svg)
 message AccommodationSearchParameters {
   // The geo location used for the search.
   oneof geo_location {

--- a/proto/cmp/services/accommodation/v4/search_query_types.proto
+++ b/proto/cmp/services/accommodation/v4/search_query_types.proto
@@ -11,6 +11,10 @@ import "cmp/types/v4/traveller.proto";
 // Represents a search query for accommodations.
 // Please note that multiple of these can be given in a single request and must
 // be treated completely individual.
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v4/search_query_types.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v4/search_query_types.proto.dot.svg)
 message AccommodationSearchQuery {
   // Integer query ID. This must be unique per search request.
   uint32 query_id = 1;

--- a/proto/cmp/services/accommodation/v4/short_list.proto
+++ b/proto/cmp/services/accommodation/v4/short_list.proto
@@ -40,6 +40,6 @@ message AccommodationProductShortListResponse {
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service AccommodationProductShortListService {
   // Returns product list for accommodation (properties) with only supplier codes.
-  // This is an alternative to `AccommodationProductList`.
+  // This can then be used to identify new or updated properties for mapping purposes.
   rpc AccommodationProductShortList(AccommodationProductShortListRequest) returns (AccommodationProductShortListResponse);
 }

--- a/proto/cmp/services/accommodation/v4/short_list.proto
+++ b/proto/cmp/services/accommodation/v4/short_list.proto
@@ -33,9 +33,9 @@ message AccommodationProductShortListResponse {
 // Accommodation product short list service definition. This is an alternative
 // to `AccommodationProductListService`.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v4/list.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v4/short_list.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v4/list.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/accommodation/v4/short_list.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service AccommodationProductShortListService {

--- a/proto/cmp/services/activity/v3/search_parameters_types.proto
+++ b/proto/cmp/services/activity/v3/search_parameters_types.proto
@@ -9,9 +9,9 @@ import "cmp/types/v3/price.proto";
 
 // These are Activity specific search parameters
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search_parameters_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v3/search_parameters_types.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search_parameters_types.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v3/search_parameters_types.proto.dot.svg)
 message ActivitySearchParameters {
   // Specify the language(s) a potential guide should speak for example a tour in
   // the Anne Frank house in Amsterdam in French or the tour at the pyramids in

--- a/proto/cmp/services/activity/v4/activity_types.proto
+++ b/proto/cmp/services/activity/v4/activity_types.proto
@@ -267,26 +267,18 @@ message ActivityService {
     max_bytes: 512
   }];
 
-  // TODO: Should name and description be multi-lingual?
+  repeated cmp.types.v4.LocalizedString names = 2 [(buf.validate.field).repeated = {
+    min_items: 0
+    max_items: 100
+  }];
 
-  // Service Name
-  string name = 2 [(buf.validate.field).string.max_bytes = 512];
-
-  // Service Description
-  string description = 3 [(buf.validate.field).string.max_bytes = 512];
+  repeated cmp.types.v4.LocalizedDescriptionSet descriptions = 3 [(buf.validate.field).repeated = {
+    min_items: 0
+    max_items: 100
+  }];
 
   // Included items in the activity service
   repeated string included = 4 [(buf.validate.field).repeated = {
-    min_items: 0
-    max_items: 100
-    items: {
-      string: {max_bytes: 512}
-    }
-  }];
-
-  // Excluded items in the activity service
-  // FIXME: Should we keep this?
-  repeated string excluded = 5 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100
     items: {

--- a/proto/cmp/services/activity/v4/activity_types.proto
+++ b/proto/cmp/services/activity/v4/activity_types.proto
@@ -19,6 +19,12 @@ import "cmp/types/v4/redemption.proto";
 import "cmp/types/v4/seat_map.proto";
 import "google/protobuf/timestamp.proto";
 
+// Activity
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/activity_types.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/activity_types.proto.dot.svg)
+
 message ActivityInfo {
   // Ex: "2023-08-28T12:03:50", specifying when the static data of a product was
   // last updated
@@ -177,8 +183,7 @@ message ActivityExtendedInfo {
   uint32 min_participants = 26;
 
   // Maximum number of participants allowed for the activity.
-  // Ex: The same je// Supplier Product codes for the result. These must match the supplier codes
-  // provided in the ProductList and ProductInfo messages.ep safari might have a maximum capacity of 10 participants
+  // Ex: The same jeep safari might have a maximum capacity of 10 participants
   // due to vehicle size limitations or safety regulations.
   uint32 max_participants = 27;
 

--- a/proto/cmp/services/activity/v4/activity_types.proto
+++ b/proto/cmp/services/activity/v4/activity_types.proto
@@ -121,13 +121,13 @@ message ActivityExtendedInfo {
   // The category of this activity according to the defined enum
   cmp.services.activity.v4.ActivityCategory category = 12 [(buf.validate.field).enum = {defined_only: true}];
 
-  // Category name which describes the category
+  // Category name which describes the `category`
   string category_name = 13 [(buf.validate.field).string.max_bytes = 512];
 
   // The type of this activity according to the defined enum
   cmp.services.activity.v4.ActivityType type = 14 [(buf.validate.field).enum = {defined_only: true}];
 
-  // Type name which describes type_code
+  // Type name which describes `type`
   string type_name = 15 [(buf.validate.field).string.max_bytes = 512];
 
   // Duration range (min, max) of the activity in minutes

--- a/proto/cmp/services/activity/v4/activity_types.proto
+++ b/proto/cmp/services/activity/v4/activity_types.proto
@@ -24,7 +24,6 @@ import "google/protobuf/timestamp.proto";
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/activity_types.proto.dot.xs.svg)
 //
 // [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/activity_types.proto.dot.svg)
-
 message ActivityInfo {
   // Ex: "2023-08-28T12:03:50", specifying when the static data of a product was
   // last updated

--- a/proto/cmp/services/activity/v4/activity_types.proto
+++ b/proto/cmp/services/activity/v4/activity_types.proto
@@ -14,15 +14,48 @@ import "cmp/types/v4/file.proto";
 import "cmp/types/v4/localized.proto";
 import "cmp/types/v4/location.proto";
 import "cmp/types/v4/product_code.proto";
+import "cmp/types/v4/product_status.proto";
 import "cmp/types/v4/redemption.proto";
 import "cmp/types/v4/seat_map.proto";
 import "google/protobuf/timestamp.proto";
 
+message ActivityInfo {
+  // Ex: "2023-08-28T12:03:50", specifying when the static data of a product was
+  // last updated
+  //
+  // Timestamps may be used for both off-chain and on-chain operations.
+  // For on-chain operations, only seconds are supported, and nanoseconds
+  // will be ignored.
+  google.protobuf.Timestamp last_modified = 1;
+
+  // Supplier Product codes for the activity. This is the main identifier
+  // for an activity product.
+  cmp.types.v4.SupplierProductCode supplier_code = 2 [(buf.validate.field).required = true];
+
+  // Additional product codes, which also identify the activity but usually
+  // from external mapping providers. Especially useful in the context of
+  // receiving activities from different suppliers to identify whether
+  // they are the same as the supplier specific codes will be different.
+  repeated cmp.types.v4.ProductCode product_codes = 3 [(buf.validate.field).repeated = {
+    min_items: 0
+    max_items: 500
+  }];
+
+  // Location of where the activity takes place
+  cmp.services.activity.v4.ActivityLocation location = 4 [(buf.validate.field).required = true];
+
+  // The general status of this property. Only active properties can be taken
+  // into account for further processing and will only be returned in search
+  // results. Deactivated properties can be still included in the static data
+  // but this state is reserved for properties which are about to be listed
+  // or are about to be completely removed soon.
+  cmp.types.v4.ProductStatus status = 5 [(buf.validate.field).required = true];
+}
+
 // Activity static info
 message ActivityExtendedInfo {
-  // Supplier Product codes for the result. These must match the supplier codes
-  // provided in the ProductList and ProductInfo messages.
-  cmp.types.v4.SupplierProductCode supplier_code = 1 [(buf.validate.field).required = true];
+  // Basic activity information usually used for mapping / decision-making
+  cmp.services.activity.v4.ActivityInfo activity = 1 [(buf.validate.field).required = true];
 
   // Definition of the units provided in this activity. This allows different
   // activities for one product like "Windsurfing" and "Kitesurfing"
@@ -52,87 +85,83 @@ message ActivityExtendedInfo {
     max_items: 100
   }];
 
-  // Location of where the activity takes place
-  cmp.services.activity.v4.ActivityLocation location = 6 [(buf.validate.field).required = true];
-
   // Activity Features
-  repeated cmp.services.activity.v4.ActivityFeature features = 7 [(buf.validate.field).repeated = {
+  repeated cmp.services.activity.v4.ActivityFeature features = 6 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100
   }];
 
   // Tags
-  repeated cmp.services.activity.v4.ActivityTag tags = 8 [(buf.validate.field).repeated = {
+  repeated cmp.services.activity.v4.ActivityTag tags = 7 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100
   }];
 
   // Languages in which the activity is available
-  repeated cmp.types.v1.Language spoken_languages = 9 [(buf.validate.field).repeated = {
+  repeated cmp.types.v1.Language spoken_languages = 8 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100
   }];
 
   // Contact Info; Address, Email, Phone, Urls
-  cmp.types.v4.ContactInfo contact_info = 10;
+  cmp.types.v4.ContactInfo contact_info = 9;
 
   // Images
-  repeated cmp.types.v4.Image images = 11 [(buf.validate.field).repeated = {
+  repeated cmp.types.v4.Image images = 10 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100
   }];
 
   // Videos
-  repeated cmp.types.v4.Video videos = 12 [(buf.validate.field).repeated = {
+  repeated cmp.types.v4.Video videos = 11 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100
   }];
 
-  // Activity Category Code
-  string category_code = 13 [(buf.validate.field).string.max_bytes = 512];
+  // The category of this activity according to the defined enum
+  cmp.services.activity.v4.ActivityCategory category = 12 [(buf.validate.field).enum = {defined_only: true}];
 
-  // Category name which describes the category_code
-  string category_name = 14 [(buf.validate.field).string.max_bytes = 512];
+  // Category name which describes the category
+  string category_name = 13 [(buf.validate.field).string.max_bytes = 512];
 
-  // Type Code
-  string type_code = 15 [(buf.validate.field).string.max_bytes = 512];
+  // The type of this activity according to the defined enum
+  cmp.services.activity.v4.ActivityType type = 14 [(buf.validate.field).enum = {defined_only: true}];
 
   // Type name which describes type_code
-  string type_name = 16 [(buf.validate.field).string.max_bytes = 512];
+  string type_name = 15 [(buf.validate.field).string.max_bytes = 512];
 
   // Duration range (min, max) of the activity in minutes
-  cmp.types.v4.DurationRange duration_range = 17;
+  cmp.types.v4.DurationRange duration_range = 16;
 
   // Time given for confirmation before the offer expires
-  cmp.types.v4.Duration max_confirmation_duration = 18;
+  cmp.types.v4.Duration max_confirmation_duration = 17;
 
   // Allow Free Sale
-  bool allow_free_sale = 19;
+  bool allow_free_sale = 18;
 
   // The ability to confirm instantly
-  bool instant_confirmation = 20;
+  bool instant_confirmation = 19;
 
   // Can be delivered instantly
-  bool instant_delivery = 21;
+  bool instant_delivery = 20;
 
   // Check availability
-  bool availability_required = 22;
+  bool availability_required = 21;
 
   // Availability Type
-  // FIXME: Explain what this is used for. Can this be an enum?
-  string availability_type = 23 [(buf.validate.field).string.max_bytes = 512];
+  cmp.services.activity.v4.ActivityAvailabilityType availability_type = 22 [(buf.validate.field).enum = {defined_only: true}];
 
   // Delivery types for the activity.
   //
   // Formats; such as QR Code, NFT, Ticket, ... etc
   // Methods; such as Email, SMS, Post, ... etc
-  repeated cmp.types.v4.Delivery delivery_types = 24 [(buf.validate.field).repeated = {
+  repeated cmp.types.v4.Delivery delivery_types = 23 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100
   }];
 
   // Redemption method
-  repeated cmp.types.v4.RedemptionMethod redemption_methods = 25 [(buf.validate.field).repeated = {
+  repeated cmp.types.v4.RedemptionMethod redemption_methods = 24 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100
   }];
@@ -140,25 +169,18 @@ message ActivityExtendedInfo {
   // Context for Inventory system concepts that need to be included in an info
   // response, like an OwnerCode, PTC_OfferParameters, Tax codes, Disclosure RefID,
   // etc. or a serialized combination of these codes.
-  string context = 26 [(buf.validate.field).string.max_bytes = 512];
-
-  // Ex: "2023-08-28T12:03:50", specifying when the static data of a product was
-  // last updated
-  //
-  // Timestamps may be used for both off-chain and on-chain operations.
-  // For on-chain operations, only seconds are supported, and nanoseconds
-  // will be ignored.
-  google.protobuf.Timestamp last_modified = 27;
+  string context = 25 [(buf.validate.field).string.max_bytes = 512];
 
   // Minimum number of participants required for the activity to proceed.
   // Ex: A jeep safari might require at least 5 participants to operate,
   // meaning the activity might be cancelled if fewer than 5 people book it.
-  uint32 min_participants = 28;
+  uint32 min_participants = 26;
 
   // Maximum number of participants allowed for the activity.
-  // Ex: The same jeep safari might have a maximum capacity of 10 participants
+  // Ex: The same je// Supplier Product codes for the result. These must match the supplier codes
+  // provided in the ProductList and ProductInfo messages.ep safari might have a maximum capacity of 10 participants
   // due to vehicle size limitations or safety regulations.
-  uint32 max_participants = 29;
+  uint32 max_participants = 27;
 
   option (buf.validate.message) = {
     cel: {
@@ -176,15 +198,9 @@ message ActivityExtendedInfo {
   // them for only requesting seat map availabilities after each search.
   // The seat map id for the offer when doing a search will then be
   // one of the seat_map_ids values defined here.
-  repeated cmp.types.v4.SeatMapID seat_map_ids = 30;
-
-  // Additional product codes, which also identify the activity but usually
-  // from external mapping providers. Especially useful in the context of
-  // receiving activities from different suppliers to identify whether
-  // they are the same as the supplier specific codes will be different.
-  repeated cmp.types.v4.ProductCode product_codes = 31 [(buf.validate.field).repeated = {
+  repeated cmp.types.v4.SeatMapID seat_map_ids = 28 [(buf.validate.field).repeated = {
     min_items: 0
-    max_items: 500
+    max_items: 100
   }];
 }
 
@@ -195,7 +211,7 @@ message ActivityLocation {
   // Geo Tree. Country, region, city_or_resort
   cmp.types.v4.GeoTree geo_tree = 2;
 
-  // Coordinate
+  // Exact coordinates of the activity location
   cmp.types.v4.Coordinates coordinates = 3;
 
   // At least one location field must be provided
@@ -295,9 +311,6 @@ message TransferZone {
   }];
 
   // Geo tree type, represented by Country, Region, and City_or_Resort.
-  //
-  // FIXME: Is this level of identification sufficient for transfer zones?
-  // Do we need more detail? (like GeoCircle, etc..)
   cmp.types.v4.GeoTree geo_tree = 2 [(buf.validate.field).required = true];
 
   // pick-up and drop-off information about location and time
@@ -327,4 +340,110 @@ message ActivityTag {
 
   // Description
   string description = 2 [(buf.validate.field).string.max_bytes = 512];
+}
+
+// This message is used to specify the supplier codes and their status.
+message ActivityShortListItem {
+  // Supplier codes for the products that are modified after the timestamp in
+  // `ActivityProductShortListRequest`. The supplier codes can be used in
+  // the `ActivityProductShortListRequest` or in the `ActivityProductInfoRequest`
+  // for more or all details.
+  cmp.types.v4.SupplierProductCode supplier_code = 1 [(buf.validate.field).required = true];
+
+  // Status of the activity. This is used when the "ShortList" or the "ProductList"
+  // are pulled. New or modified products have "activated" and activities that are
+  // no longer available from this supplier, will have the status "deactivated".
+  // In case a activity has the status "deactivated" no search results will be
+  // returned for that activity and a ProductInfo request might not return any
+  // details.
+  cmp.types.v4.ProductStatus status = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+}
+
+enum ActivityAvailabilityType {
+  // Default/unspecified state.
+  // Must be zero according to protobuf best practices.
+  ACTIVITY_AVAILABILITY_TYPE_UNSPECIFIED = 0;
+
+  // Activities or products with fixed start or departure times.
+  // Users must select a particular start time from predefined options.
+  // Common for scheduled tours, shows, or transfers with set timings.
+  ACTIVITY_AVAILABILITY_TYPE_START_TIME = 1;
+
+  // Activities available during certain venue opening hours.
+  // Users can visit or participate anytime within the defined time window.
+  // Suitable for museums, parks, exhibits where no fixed start time is required.
+  ACTIVITY_AVAILABILITY_TYPE_OPENING_HOURS = 2;
+
+  // Activities or products offering flexible scheduling without fixed times.
+  // Customers have freedom to choose a date/time within a broad range.
+  // Often for rentals, self-guided experiences, or services adaptable to user needs.
+  ACTIVITY_AVAILABILITY_TYPE_FLEXIBLE = 3;
+
+  // Activities available starting on a specific date but not tied to fixed start times.
+  // Useful for seasonal openings or availability windows beginning on a date.
+  ACTIVITY_AVAILABILITY_TYPE_OPEN_DATE = 4;
+
+  // Activities available on multiple discrete dates which can be selected from a calendar.
+  // Provides a user interface for date selection, commonly used for events, classes, or limited-time offers.
+  ACTIVITY_AVAILABILITY_TYPE_CALENDAR = 5;
+}
+
+// Enum representing broad categories of activities, including entertainment
+enum ActivityCategory {
+  // Default unspecified category
+  ACTIVITY_CATEGORY_UNSPECIFIED = 0;
+
+  // Tours including guided sightseeing, city, or nature excursions
+  ACTIVITY_CATEGORY_TOUR = 1;
+
+  // Visits to museums, parks, historical sites, or attractions
+  ACTIVITY_CATEGORY_ATTRACTION = 2;
+
+  // Outdoor adventures like hiking, water sports, safaris, etc.
+  ACTIVITY_CATEGORY_ADVENTURE = 3;
+
+  // Experiences such as classes, workshops, tastings, or immersive activities
+  ACTIVITY_CATEGORY_EXPERIENCE = 4;
+
+  // Transportation services such as airports, hotels, or intercity shuttles
+  ACTIVITY_CATEGORY_TRANSFER = 5;
+
+  // Cruises, boat trips, or sea excursions
+  ACTIVITY_CATEGORY_CRUISE = 6;
+
+  // Entertainment events including concerts, live shows, theater, or music performances
+  ACTIVITY_CATEGORY_ENTERTAINMENT = 7; // Added to cover concerts and live performances.
+}
+
+// Enum specifying detailed activity types, including concerts and shows
+enum ActivityType {
+  // Default or unspecified type
+  ACTIVITY_TYPE_UNSPECIFIED = 0;
+
+  // Guided city or sightseeing tours
+  ACTIVITY_TYPE_GUIDED_TOUR = 1;
+
+  // Self-guided exploration
+  ACTIVITY_TYPE_SELF_GUIDED = 2;
+
+  // Museum, gallery, or attraction tickets
+  ACTIVITY_TYPE_TICKET = 3;
+
+  // Cultural or entertainment shows like concerts, theater, dance
+  ACTIVITY_TYPE_SHOW = 4; // Suitable for concerts, performances, live music.
+
+  // Adventure activities like zip-lining, water sports, etc.
+  ACTIVITY_TYPE_ADVENTURE_SPORT = 5;
+
+  // Classes, workshops, tastings
+  ACTIVITY_TYPE_WORKSHOP = 6;
+
+  // Transfers (airport, hotel, etc.)
+  ACTIVITY_TYPE_SHUTTLE_TRANSFER = 7;
+
+  // Boat or sea excursions
+  ACTIVITY_TYPE_BOAT_TOUR = 8;
 }

--- a/proto/cmp/services/activity/v4/activity_types.proto
+++ b/proto/cmp/services/activity/v4/activity_types.proto
@@ -11,36 +11,12 @@ import "cmp/types/v4/delivery.proto";
 import "cmp/types/v4/description.proto";
 import "cmp/types/v4/duration.proto";
 import "cmp/types/v4/file.proto";
+import "cmp/types/v4/localized.proto";
 import "cmp/types/v4/location.proto";
 import "cmp/types/v4/product_code.proto";
 import "cmp/types/v4/redemption.proto";
 import "cmp/types/v4/seat_map.proto";
 import "google/protobuf/timestamp.proto";
-
-// Activity
-//
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v3/activity_types.proto.dot.xs.svg)
-//
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v3/activity_types.proto.dot.svg)
-message Activity {
-  // Supplier Product codes for the result.
-  cmp.types.v4.SupplierProductCode supplier_code = 1 [(buf.validate.field).required = true];
-
-  // The code must match one of the defined units provided in the ProductList
-  // and ProductInfo message.
-  // See: ActivityExtendedInfo.units.code
-  string unit_code = 2 [(buf.validate.field).string.max_bytes = 512];
-
-  // The code must match one of the defined units provided in the ProductList
-  // and ProductInfo message.
-  // See: ActivityExtendedInfo.services.code
-  string service_code = 3 [(buf.validate.field).string.max_bytes = 512];
-
-  // Reference to the applicable seat map of this activity offer. Must match a
-  // seat_map_id which was already defined in the static data.
-  // See: ActivityExtendedInfo.seat_map_ids
-  cmp.types.v4.SeatMapID seat_map_id = 4;
-}
 
 // Activity static info
 message ActivityExtendedInfo {
@@ -257,27 +233,28 @@ message PickupDropoffEvent {
   cmp.types.v4.Coordinates coordinates = 5;
 }
 
-// The unit  gives us a choice of the different options that are available in an
+// The unit gives us a choice of the different options that are available in an
 // activity, like for example a normal ticket or a VIP ticket. a 2 hour or 4 hour
 // jeep safari. A ticket to a specific section of a stadium.
 message ActivityUnit {
-  // Schedule
-  // FIXME: Should this be here? This is used in extended info (static info)
-  cmp.types.v4.DateTimeRange schedule = 1;
-
-  // Unit Code
-  string code = 2 [(buf.validate.field).string = {
+  // Unique identifier of a unit inside of an activity
+  string code = 1 [(buf.validate.field).string = {
     min_len: 1
     max_bytes: 512
   }];
 
-  // TODO: Should name and description be multi-lingual?
+  // Schedule of this particular unit with one defined start and end
+  cmp.types.v4.DateTimeRange schedule = 2;
 
-  // Unit Name
-  string name = 3 [(buf.validate.field).string.max_bytes = 512];
+  repeated cmp.types.v4.LocalizedString names = 3 [(buf.validate.field).repeated = {
+    min_items: 0
+    max_items: 100
+  }];
 
-  // Unit Description
-  string description = 4 [(buf.validate.field).string.max_bytes = 512];
+  repeated cmp.types.v4.LocalizedDescriptionSet descriptions = 4 [(buf.validate.field).repeated = {
+    min_items: 0
+    max_items: 100
+  }];
 }
 
 // Services can be selected like do we go to the activity by ourselves or is a

--- a/proto/cmp/services/activity/v4/info.proto
+++ b/proto/cmp/services/activity/v4/info.proto
@@ -7,30 +7,21 @@ import "cmp/services/activity/v4/activity_types.proto";
 import "cmp/types/v1/language.proto";
 import "cmp/types/v4/common.proto";
 import "cmp/types/v4/product_code.proto";
-import "google/protobuf/timestamp.proto";
 
 message ActivityProductInfoRequest {
   // Message header
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];
 
-  // Only respond with the products that are new, modified or deactivated after this
-  // timestamp.
-  //
-  // Timestamps may be used for both off-chain and on-chain operations.
-  // For on-chain operations, only seconds are supported, and nanoseconds
-  // will be ignored.
-  google.protobuf.Timestamp modified_after = 2; // FIXME: Does this makes sense when we have supplier code list?
-
   // Languages to be included in the response for descriptions. Minimum of 1
   // language is required.
-  repeated cmp.types.v1.Language languages = 3 [(buf.validate.field).repeated = {
+  repeated cmp.types.v1.Language languages = 2 [(buf.validate.field).repeated = {
     min_items: 1
     max_items: 10
     unique: true
   }];
 
   // Activity codes
-  repeated cmp.types.v4.SupplierProductCode supplier_codes = 4 [(buf.validate.field).repeated = {
+  repeated cmp.types.v4.SupplierProductCode supplier_codes = 3 [(buf.validate.field).repeated = {
     min_items: 1
     max_items: 100 // Default max items
   }];

--- a/proto/cmp/services/activity/v4/info.proto
+++ b/proto/cmp/services/activity/v4/info.proto
@@ -40,9 +40,9 @@ message ActivityProductInfoResponse {
 
 // Activity product info service definition
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v3/info.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/info.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v3/info.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/info.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service ActivityProductInfoService {

--- a/proto/cmp/services/activity/v4/list.proto
+++ b/proto/cmp/services/activity/v4/list.proto
@@ -3,28 +3,33 @@ syntax = "proto3";
 package cmp.services.activity.v4;
 
 import "buf/validate/validate.proto";
+import "cmp/services/activity/v4/activity_types.proto";
 import "cmp/types/v4/common.proto";
 import "cmp/types/v4/product_code.proto";
-import "google/protobuf/timestamp.proto";
 
 message ActivityProductListRequest {
   // Message header
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];
 
-  // Only respond with the products that are modified after this timestamp
-  //
-  // Timestamps may be used for both off-chain and on-chain operations.
-  // For on-chain operations, only seconds are supported, and nanoseconds
-  // will be ignored.
-  google.protobuf.Timestamp modified_after = 2;
+  // The supplier product codes can be used to pull more details for (new & updated)
+  // activities that are required for mapping, after the "ShortList" was pulled with the
+  // "modified_after" parameter. This is specifically useful to avoid pulling the
+  // complete "Product Info" twice, once for mapping and once to store the multi-lingual
+  // content and imagery.
+  repeated cmp.types.v4.SupplierProductCode supplier_codes = 2 [(buf.validate.field).repeated = {
+    min_items: 1
+    max_items: 100 // Default max items
+  }];
 }
 
 message ActivityProductListResponse {
   // Message header
   cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
 
-  // List of supplier codes of activities
-  repeated cmp.types.v4.SupplierProductCode supplier_codes = 2;
+  // List of basic identifiers and informations for activities
+  // Used to decide whether to pull the full information for mapping purposes
+  // With a ActivityProductInfoRequest.
+  repeated cmp.services.activity.v4.ActivityInfo activities = 2;
 }
 
 // This service is used to get a product list for activities.
@@ -35,6 +40,5 @@ message ActivityProductListResponse {
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service ActivityProductListService {
-  // Gets an optional `modified_after` date and returns a product list.
   rpc ActivityProductList(ActivityProductListRequest) returns (ActivityProductListResponse);
 }

--- a/proto/cmp/services/activity/v4/list.proto
+++ b/proto/cmp/services/activity/v4/list.proto
@@ -34,9 +34,9 @@ message ActivityProductListResponse {
 
 // This service is used to get a product list for activities.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v3/list.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/list.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v3/list.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/list.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service ActivityProductListService {

--- a/proto/cmp/services/activity/v4/search.proto
+++ b/proto/cmp/services/activity/v4/search.proto
@@ -154,9 +154,9 @@ message ActivitySearchResponse {
 //
 // Takes `ActivitySearchRequest` message type and returns `ActivitySearchResponse` message type.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v3/search.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/search.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v3/search.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/search.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service ActivitySearchService {

--- a/proto/cmp/services/activity/v4/search_parameters_types.proto
+++ b/proto/cmp/services/activity/v4/search_parameters_types.proto
@@ -14,9 +14,9 @@ import "cmp/types/v4/product_code.proto";
 // While all fields in this message are optional at the message level, each supplier
 // may define their own minimum set of required filter parameters.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search_parameters_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/search_parameters_types.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v2/search_parameters_types.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/search_parameters_types.proto.dot.svg)
 message ActivitySearchParameters {
   // Specify the language(s) a potential guide should speak for example a tour in
   // the Anne Frank house in Amsterdam in French or the tour at the pyramids in

--- a/proto/cmp/services/activity/v4/search_result_types.proto
+++ b/proto/cmp/services/activity/v4/search_result_types.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package cmp.services.activity.v4;
 
 import "buf/validate/validate.proto";
-import "cmp/services/activity/v4/activity_types.proto";
 import "cmp/types/v4/bookability.proto";
 import "cmp/types/v4/price.proto";
 import "cmp/types/v4/product_code.proto";
@@ -38,10 +37,9 @@ message ActivitySearchResult {
   // See: ActivityExtendedInfo.seat_map_ids
   cmp.types.v4.SeatMapID seat_map_id = 5;
 
-  // Pickup Dropoff
-  // FIXME: Why do we need this here? The zone is already defined in the static data and not used at all anywhere else.
-  // We need to clarify this
-  repeated cmp.services.activity.v4.PickupDropoffEvent pickup_dropoff_events = 6 [(buf.validate.field).repeated = {
+  // Identifiers of the transfer zones applicable for this search result.
+  // Meaning that every PickupDropoffEvent in these zones is valid for this result.
+  repeated string zone_codes = 6 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100
   }];

--- a/proto/cmp/services/activity/v4/search_result_types.proto
+++ b/proto/cmp/services/activity/v4/search_result_types.proto
@@ -11,9 +11,9 @@ import "cmp/types/v4/seat_map.proto";
 // This type represents a search result and is used in the `ActivitySearchResponse`
 // message.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v3/search_result_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/search_result_types.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v3/search_result_types.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/search_result_types.proto.dot.svg)
 message ActivitySearchResult {
   // This is an increasing number starting at 0 and increasing by 1 for every search
   // result.

--- a/proto/cmp/services/activity/v4/search_result_types.proto
+++ b/proto/cmp/services/activity/v4/search_result_types.proto
@@ -5,8 +5,9 @@ package cmp.services.activity.v4;
 import "buf/validate/validate.proto";
 import "cmp/services/activity/v4/activity_types.proto";
 import "cmp/types/v4/bookability.proto";
-import "cmp/types/v4/datetime_range.proto";
 import "cmp/types/v4/price.proto";
+import "cmp/types/v4/product_code.proto";
+import "cmp/types/v4/seat_map.proto";
 
 // This type represents a search result and is used in the `ActivitySearchResponse`
 // message.
@@ -19,27 +20,36 @@ message ActivitySearchResult {
   // result.
   uint32 result_id = 1;
 
-  // Activity basic info
-  cmp.services.activity.v4.Activity info = 2 [(buf.validate.field).required = true];
+  // Supplier Product codes for the result.
+  cmp.types.v4.SupplierProductCode supplier_code = 2 [(buf.validate.field).required = true];
 
-  // Schedule
-  // FIXME: Explain this
-  cmp.types.v4.DateTimeRange schedule = 3;
+  // The code must match one of the defined units provided in the ProductList
+  // and ProductInfo message.
+  // See: ActivityExtendedInfo.units.code
+  string unit_code = 3 [(buf.validate.field).string.max_bytes = 512];
 
-  // Activity location
-  // FIXME: Remove? It's already in the extended info.
-  cmp.services.activity.v4.ActivityLocation location = 4;
+  // The code must match one of the defined units provided in the ProductList
+  // and ProductInfo message.
+  // See: ActivityExtendedInfo.services.code
+  string service_code = 4 [(buf.validate.field).string.max_bytes = 512];
+
+  // Reference to the applicable seat map of this activity offer. Must match a
+  // seat_map_id which was already defined in the static data.
+  // See: ActivityExtendedInfo.seat_map_ids
+  cmp.types.v4.SeatMapID seat_map_id = 5;
 
   // Pickup Dropoff
-  repeated cmp.services.activity.v4.PickupDropoffEvent pickup_dropoff_events = 5 [(buf.validate.field).repeated = {
+  // FIXME: Why do we need this here? The zone is already defined in the static data and not used at all anywhere else.
+  // We need to clarify this
+  repeated cmp.services.activity.v4.PickupDropoffEvent pickup_dropoff_events = 6 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100
   }];
 
   // Represents the complete pricing information for a product or service, including
   // both the total price value and an optional breakdown of price components.
-  cmp.types.v4.TotalPrice total_price = 8 [(buf.validate.field).required = true];
+  cmp.types.v4.TotalPrice total_price = 7 [(buf.validate.field).required = true];
 
   // Status of the result, whether it is immediately bookable or not
-  cmp.types.v4.Bookability bookability = 9 [(buf.validate.field).required = true];
+  cmp.types.v4.Bookability bookability = 8 [(buf.validate.field).required = true];
 }

--- a/proto/cmp/services/activity/v4/short_list.proto
+++ b/proto/cmp/services/activity/v4/short_list.proto
@@ -33,9 +33,9 @@ message ActivityProductShortListResponse {
 // Activity product short list service definition. This is an alternative
 // to `ActivityProductListService`.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/list.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/short_list.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/list.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/short_list.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service ActivityProductShortListService {

--- a/proto/cmp/services/activity/v4/short_list.proto
+++ b/proto/cmp/services/activity/v4/short_list.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+
+package cmp.services.activity.v4;
+
+import "buf/validate/validate.proto";
+import "cmp/services/activity/v4/activity_types.proto";
+import "cmp/types/v4/common.proto";
+import "google/protobuf/timestamp.proto";
+
+// Request a list of modified activities.
+message ActivityProductShortListRequest {
+  // Common request header used in every request.
+  cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];
+
+  // Only respond with the products that are modified after this timestamp
+  //
+  // The "modified_after" parameter is used to identify updated products from
+  // Suppliers.
+  google.protobuf.Timestamp modified_after = 2;
+}
+
+// Respond a list of modified activities.
+message ActivityProductShortListResponse {
+  // Common response header used in every response.
+  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+
+  // Supplier codes and status for the products that are modified after the timestamp
+  // in the `ActivityProductShortListRequest`. If there are no changes, the list
+  // will be empty.
+  repeated cmp.services.activity.v4.ActivityShortListItem activity_short_list_items = 2;
+}
+
+// Activity product short list service definition. This is an alternative
+// to `ActivityProductListService`.
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/list.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/activity/v4/list.proto.dot.svg)
+//
+/// @custom:cmp-service type:product routing:p2p on-chain:false
+service ActivityProductShortListService {
+  // Returns product list for activity with only supplier codes.
+  // This can then be used to identify new or updated activities for mapping purposes.
+  rpc ActivityProductShortList(ActivityProductShortListRequest) returns (ActivityProductShortListResponse);
+}

--- a/proto/cmp/services/book/v4/mint.proto
+++ b/proto/cmp/services/book/v4/mint.proto
@@ -120,9 +120,9 @@ message MintResponse {
   bool cancellable = 12;
 }
 
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v3/mint.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v4/mint.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v3/mint.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v4/mint.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:true
 service MintService {

--- a/proto/cmp/services/book/v4/validate.proto
+++ b/proto/cmp/services/book/v4/validate.proto
@@ -95,9 +95,9 @@ message ValidationObject {
   }];
 }
 
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v3/validate.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v4/validate.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v3/validate.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v4/validate.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service ValidationService {

--- a/proto/cmp/services/cancellation/v1/counter.proto
+++ b/proto/cmp/services/cancellation/v1/counter.proto
@@ -8,6 +8,10 @@ import "cmp/types/v3/evm_transaction.proto";
 import "cmp/types/v3/price.proto";
 
 // Request for countering a cancellation
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/counter.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/counter.proto.dot.svg)
 message CounterCancellationRequest {
   // Request header
   cmp.types.v1.RequestHeader header = 1;

--- a/proto/cmp/services/cancellation/v1/finalize.proto
+++ b/proto/cmp/services/cancellation/v1/finalize.proto
@@ -6,6 +6,11 @@ import "cmp/types/v1/common.proto";
 import "cmp/types/v3/evm_transaction.proto";
 import "cmp/types/v3/price.proto";
 
+// Request for finalization of a cancellation proposal
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/finalize.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/finalize.proto.dot.svg)
 message FinalizeCancellationRequest {
   // The request header
   cmp.types.v1.RequestHeader header = 1;

--- a/proto/cmp/services/cancellation/v1/initiate.proto
+++ b/proto/cmp/services/cancellation/v1/initiate.proto
@@ -7,6 +7,11 @@ import "cmp/types/v1/common.proto";
 import "cmp/types/v3/evm_transaction.proto";
 import "cmp/types/v3/price.proto";
 
+// Request for initiation of a cancellation proposal
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/initiate.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/initiate.proto.dot.svg)
 message InitiateCancellationRequest {
   // The request header
   cmp.types.v1.RequestHeader header = 1;

--- a/proto/cmp/services/cancellation/v1/reason.proto
+++ b/proto/cmp/services/cancellation/v1/reason.proto
@@ -2,6 +2,11 @@ syntax = "proto3";
 
 package cmp.services.cancellation.v1;
 
+// Cancellation Reasons
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/reason.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/reason.proto.dot.svg)
 enum CancellationReason {
   // Default unspecified value
   CANCELLATION_REASON_UNSPECIFIED = 0;

--- a/proto/cmp/services/cancellation/v1/reject.proto
+++ b/proto/cmp/services/cancellation/v1/reject.proto
@@ -7,6 +7,10 @@ import "cmp/types/v1/common.proto";
 import "cmp/types/v3/evm_transaction.proto";
 
 // Request for cancellation rejection
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/reject.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/reject.proto.dot.svg)
 message RejectCancellationRequest {
   // Request Header
   cmp.types.v1.RequestHeader header = 1;

--- a/proto/cmp/services/cancellation/v1/withdraw.proto
+++ b/proto/cmp/services/cancellation/v1/withdraw.proto
@@ -7,6 +7,10 @@ import "cmp/types/v1/common.proto";
 import "cmp/types/v3/evm_transaction.proto";
 
 // Request for withdrawal of an active cancellation proposal
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/withdraw.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/withdraw.proto.dot.svg)
 message WithdrawCancellationRequest {
   // Request header
   cmp.types.v1.RequestHeader header = 1;

--- a/proto/cmp/services/cancellation/v2/accept.proto
+++ b/proto/cmp/services/cancellation/v2/accept.proto
@@ -9,9 +9,9 @@ import "cmp/types/v4/price.proto";
 
 // Request for cancellation acceptance
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/accept.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/accept.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/accept.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/accept.proto.dot.svg)
 message AcceptCancellationRequest {
   // Request header
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];

--- a/proto/cmp/services/cancellation/v2/check.proto
+++ b/proto/cmp/services/cancellation/v2/check.proto
@@ -15,9 +15,9 @@ import "google/protobuf/timestamp.proto";
 // - Determine the exact refund amount before proceeding with actual cancellation
 // - Understand rejection reasons when cancellation is not permitted
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/check.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/check.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/check.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/check.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service CheckCancellationService {

--- a/proto/cmp/services/cancellation/v2/counter.proto
+++ b/proto/cmp/services/cancellation/v2/counter.proto
@@ -9,6 +9,10 @@ import "cmp/types/v4/evm_transaction.proto";
 import "cmp/types/v4/price.proto";
 
 // Request for countering a cancellation
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/counter.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/counter.proto.dot.svg)
 message CounterCancellationRequest {
   // Request header
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];

--- a/proto/cmp/services/cancellation/v2/finalize.proto
+++ b/proto/cmp/services/cancellation/v2/finalize.proto
@@ -7,6 +7,11 @@ import "cmp/types/v4/common.proto";
 import "cmp/types/v4/evm_transaction.proto";
 import "cmp/types/v4/price.proto";
 
+// Request for finalization of a cancellation proposal
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/finalize.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/finalize.proto.dot.svg)
 message FinalizeCancellationRequest {
   // The request header
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];

--- a/proto/cmp/services/cancellation/v2/initiate.proto
+++ b/proto/cmp/services/cancellation/v2/initiate.proto
@@ -8,6 +8,11 @@ import "cmp/types/v4/common.proto";
 import "cmp/types/v4/evm_transaction.proto";
 import "cmp/types/v4/price.proto";
 
+// Request for initiation of a cancellation proposal
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/initiate.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/initiate.proto.dot.svg)
 message InitiateCancellationRequest {
   // The request header
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];

--- a/proto/cmp/services/cancellation/v2/reject.proto
+++ b/proto/cmp/services/cancellation/v2/reject.proto
@@ -8,6 +8,10 @@ import "cmp/types/v4/common.proto";
 import "cmp/types/v4/evm_transaction.proto";
 
 // Request for cancellation rejection
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/reject.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/reject.proto.dot.svg)
 message RejectCancellationRequest {
   // Request Header
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];

--- a/proto/cmp/services/cancellation/v2/services.proto
+++ b/proto/cmp/services/cancellation/v2/services.proto
@@ -20,9 +20,9 @@ import "cmp/services/cancellation/v2/withdraw.proto";
 
 // Cancellation service
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/services.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/services.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v1/services.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/services.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:local on-chain:true
 service CancellationService {

--- a/proto/cmp/services/cancellation/v2/withdraw.proto
+++ b/proto/cmp/services/cancellation/v2/withdraw.proto
@@ -8,6 +8,10 @@ import "cmp/types/v4/common.proto";
 import "cmp/types/v4/evm_transaction.proto";
 
 // Request for withdrawal of an active cancellation proposal
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/withdraw.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/cancellation/v2/withdraw.proto.dot.svg)
 message WithdrawCancellationRequest {
   // Request header
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];

--- a/proto/cmp/services/claim/v1/claim_settlement_decision.proto
+++ b/proto/cmp/services/claim/v1/claim_settlement_decision.proto
@@ -7,6 +7,11 @@ import "cmp/types/v1/common.proto";
 import "cmp/types/v3/price.proto";
 import "google/protobuf/timestamp.proto";
 
+// Request to submit a claim settlement decision
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v1/claim_settlement_decision.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v1/claim_settlement_decision.proto.dot.svg)
 message ClaimSettlementDecisionRequest {
   // Message header
   cmp.types.v1.RequestHeader header = 1;

--- a/proto/cmp/services/claim/v1/claim_settlement_extra_info.proto
+++ b/proto/cmp/services/claim/v1/claim_settlement_extra_info.proto
@@ -6,6 +6,11 @@ import "cmp/services/claim/v1/claim_types.proto";
 import "cmp/types/v1/common.proto";
 import "google/protobuf/timestamp.proto";
 
+// Request to get extra info for claim settlement
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v1/claim_settlement_extra_info.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v1/claim_settlement_extra_info.proto.dot.svg)
 message ClaimSettlementExtraInfoRequest {
   // Message header
   cmp.types.v1.RequestHeader header = 1;

--- a/proto/cmp/services/claim/v1/get_claim_form.proto
+++ b/proto/cmp/services/claim/v1/get_claim_form.proto
@@ -6,6 +6,11 @@ import "cmp/services/claim/v1/claim_types.proto";
 import "cmp/types/v1/common.proto";
 import "cmp/types/v1/language.proto";
 
+// Request to get a claim form
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v1/get_claim_form.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v1/get_claim_form.proto.dot.svg)
 message ClaimGetFormRequest {
   // Message header
   cmp.types.v1.RequestHeader header = 1;

--- a/proto/cmp/services/claim/v1/submit_claim_form.proto
+++ b/proto/cmp/services/claim/v1/submit_claim_form.proto
@@ -5,6 +5,11 @@ package cmp.services.claim.v1;
 import "cmp/services/claim/v1/claim_types.proto";
 import "cmp/types/v1/common.proto";
 
+// Request to submit a claim form
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v1/submit_claim_form.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v1/submit_claim_form.proto.dot.svg)
 message ClaimSubmitFormRequest {
   // Message header
   cmp.types.v1.RequestHeader header = 1;

--- a/proto/cmp/services/claim/v1/submit_claim_form_extra_info.proto
+++ b/proto/cmp/services/claim/v1/submit_claim_form_extra_info.proto
@@ -5,6 +5,11 @@ package cmp.services.claim.v1;
 import "cmp/services/claim/v1/claim_types.proto";
 import "cmp/types/v1/common.proto";
 
+// Request to submit extra info for a claim form
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v1/submit_claim_form_extra_info.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v1/submit_claim_form_extra_info.proto.dot.svg)
 message ClaimSubmitFormExtraInfoRequest {
   // Message header
   cmp.types.v1.RequestHeader header = 1;

--- a/proto/cmp/services/claim/v2/claim_settlement_decision.proto
+++ b/proto/cmp/services/claim/v2/claim_settlement_decision.proto
@@ -8,6 +8,11 @@ import "cmp/types/v4/common.proto";
 import "cmp/types/v4/price.proto";
 import "google/protobuf/timestamp.proto";
 
+// Request to submit a claim settlement decision
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v2/claim_settlement_decision.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v2/claim_settlement_decision.proto.dot.svg)
 message ClaimSettlementDecisionRequest {
   // Message header
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];

--- a/proto/cmp/services/claim/v2/claim_settlement_extra_info.proto
+++ b/proto/cmp/services/claim/v2/claim_settlement_extra_info.proto
@@ -7,6 +7,11 @@ import "cmp/services/claim/v2/claim_types.proto";
 import "cmp/types/v4/common.proto";
 import "google/protobuf/timestamp.proto";
 
+// Request to get extra info for claim settlement
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v2/claim_settlement_extra_info.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v2/claim_settlement_extra_info.proto.dot.svg)
 message ClaimSettlementExtraInfoRequest {
   // Message header
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];

--- a/proto/cmp/services/claim/v2/claim_types.proto
+++ b/proto/cmp/services/claim/v2/claim_types.proto
@@ -14,9 +14,9 @@ import "cmp/types/v4/traveller.proto";
 
 // ClaimForm
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v1/claim_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v2/claim_types.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v1/claim_types.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v2/claim_types.proto.dot.svg)
 message ClaimForm {
   // Insured person or someone related who has the accident
   cmp.services.claim.v2.TravellerExtraInfo affected_person = 1;

--- a/proto/cmp/services/claim/v2/get_claim_form.proto
+++ b/proto/cmp/services/claim/v2/get_claim_form.proto
@@ -7,6 +7,11 @@ import "cmp/services/claim/v2/claim_types.proto";
 import "cmp/types/v1/language.proto";
 import "cmp/types/v4/common.proto";
 
+// Request to get a claim form
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v2/get_claim_form.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v2/get_claim_form.proto.dot.svg)
 message ClaimGetFormRequest {
   // Message header
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];

--- a/proto/cmp/services/claim/v2/services.proto
+++ b/proto/cmp/services/claim/v2/services.proto
@@ -86,9 +86,9 @@ import "cmp/services/claim/v2/submit_claim_form_extra_info.proto";
 
 // Claim services
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v1/services.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v2/services.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v1/services.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v2/services.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service ClaimService {

--- a/proto/cmp/services/claim/v2/submit_claim_form.proto
+++ b/proto/cmp/services/claim/v2/submit_claim_form.proto
@@ -6,6 +6,11 @@ import "buf/validate/validate.proto";
 import "cmp/services/claim/v2/claim_types.proto";
 import "cmp/types/v4/common.proto";
 
+// Request to submit a claim form
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v2/submit_claim_form.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v2/submit_claim_form.proto.dot.svg)
 message ClaimSubmitFormRequest {
   // Message header
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];

--- a/proto/cmp/services/claim/v2/submit_claim_form_extra_info.proto
+++ b/proto/cmp/services/claim/v2/submit_claim_form_extra_info.proto
@@ -6,6 +6,11 @@ import "buf/validate/validate.proto";
 import "cmp/services/claim/v2/claim_types.proto";
 import "cmp/types/v4/common.proto";
 
+// Request to submit extra info for a claim form
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v2/submit_claim_form_extra_info.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/claim/v2/submit_claim_form_extra_info.proto.dot.svg)
 message ClaimSubmitFormExtraInfoRequest {
   // Message header
   cmp.types.v4.RequestHeader header = 1 [(buf.validate.field).required = true];

--- a/proto/cmp/services/info/v3/entry_requirements.proto
+++ b/proto/cmp/services/info/v3/entry_requirements.proto
@@ -13,9 +13,9 @@ import "cmp/types/v4/localized.proto";
 import "cmp/types/v4/uuid.proto";
 import "google/protobuf/timestamp.proto";
 
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/info/v2/entry_requirements.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/info/v3/entry_requirements.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/info/v2/entry_requirements.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/info/v3/entry_requirements.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service CountryEntryRequirementsService {

--- a/proto/cmp/services/insurance/v1/search_query_types.proto
+++ b/proto/cmp/services/insurance/v1/search_query_types.proto
@@ -4,6 +4,11 @@ package cmp.services.insurance.v1;
 
 import "cmp/services/insurance/v1/search_parameters_types.proto";
 
+// Insurance Search Query
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v1/search_query_types.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v1/search_query_types.proto.dot.svg)
 message InsuranceSearchQuery {
   // Integer query ID, unique per search request
   int32 query_id = 1;

--- a/proto/cmp/services/insurance/v2/search_query_types.proto
+++ b/proto/cmp/services/insurance/v2/search_query_types.proto
@@ -4,6 +4,11 @@ package cmp.services.insurance.v2;
 
 import "cmp/services/insurance/v2/search_parameters_types.proto";
 
+// Insurance Search Query
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v2/search_query_types.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v2/search_query_types.proto.dot.svg)
 message InsuranceSearchQuery {
   // Integer query ID, unique per search request
   int32 query_id = 1;

--- a/proto/cmp/services/insurance/v3/info.proto
+++ b/proto/cmp/services/insurance/v3/info.proto
@@ -48,9 +48,9 @@ message InsuranceProductInfoResponse {
 
 // Insurance product info service definition
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v2/info.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v3/info.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v2/info.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v3/info.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service InsuranceProductInfoService {

--- a/proto/cmp/services/insurance/v3/insurance_types.proto
+++ b/proto/cmp/services/insurance/v3/insurance_types.proto
@@ -13,9 +13,9 @@ import "google/protobuf/timestamp.proto";
 
 // Insurance
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v2/insurance_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v3/insurance_types.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v2/insurance_types.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v3/insurance_types.proto.dot.svg)
 message Insurance {
   // Context for Inventory system concepts that need to be included in an info
   // response, like an OwnerCode, PTC_OfferParameters, Tax codes, Disclosure RefID,

--- a/proto/cmp/services/insurance/v3/list.proto
+++ b/proto/cmp/services/insurance/v3/list.proto
@@ -32,9 +32,9 @@ message InsuranceProductListResponse {
 
 // This service is used to get a product list for insurances.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v2/list.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v3/list.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v2/list.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v3/list.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service InsuranceProductListService {

--- a/proto/cmp/services/insurance/v3/search.proto
+++ b/proto/cmp/services/insurance/v3/search.proto
@@ -97,9 +97,9 @@ message InsuranceSearchResponse {
 
 // Service definition for Insurance search
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v2/search.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v3/search.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v2/search.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v3/search.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service InsuranceSearchService {

--- a/proto/cmp/services/insurance/v3/search_parameters_types.proto
+++ b/proto/cmp/services/insurance/v3/search_parameters_types.proto
@@ -13,9 +13,9 @@ import "cmp/types/v4/traveller.proto";
 
 // This type is used in search requests for parameters like insured booking, network, ... etc
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v2/search_parameters_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v3/search_parameters_types.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v2/search_parameters_types.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v3/search_parameters_types.proto.dot.svg)
 message InsuranceSearchParameters {
   // Product code list
   // Here a list of product codes would be used that could be for various specific

--- a/proto/cmp/services/insurance/v3/search_query_types.proto
+++ b/proto/cmp/services/insurance/v3/search_query_types.proto
@@ -5,6 +5,11 @@ package cmp.services.insurance.v3;
 import "buf/validate/validate.proto";
 import "cmp/services/insurance/v3/search_parameters_types.proto";
 
+// Insurance Search Query
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/services/insurance/v3/search_query_types.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/services/insurance/v3/search_query_types.proto.dot.svg)
 message InsuranceSearchQuery {
   // Integer query ID, unique per search request
   uint32 query_id = 1;

--- a/proto/cmp/services/insurance/v3/search_query_types.proto
+++ b/proto/cmp/services/insurance/v3/search_query_types.proto
@@ -7,9 +7,9 @@ import "cmp/services/insurance/v3/search_parameters_types.proto";
 
 // Insurance Search Query
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/services/insurance/v3/search_query_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v3/search_query_types.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/services/insurance/v3/search_query_types.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v3/search_query_types.proto.dot.svg)
 message InsuranceSearchQuery {
   // Integer query ID, unique per search request
   uint32 query_id = 1;

--- a/proto/cmp/services/insurance/v3/search_result_types.proto
+++ b/proto/cmp/services/insurance/v3/search_result_types.proto
@@ -9,9 +9,9 @@ import "cmp/types/v4/price.proto";
 // This type represents a search result and is used in the
 // `InsuranceSearchResponse` message.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v2/search_result_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v3/search_result_types.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v2/search_result_types.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/insurance/v3/search_result_types.proto.dot.svg)
 message InsuranceSearchResult {
   // ID for the search result. This is an increasing number starting at 0 and
   // increasing by 1 for every search result.

--- a/proto/cmp/services/notification/v3/notify.proto
+++ b/proto/cmp/services/notification/v3/notify.proto
@@ -11,9 +11,9 @@ import "google/protobuf/empty.proto";
 
 // Notification service for different events that the partner should be notified about
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/notification/v2/notify.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/notification/v3/notify.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/notification/v2/notify.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/notification/v3/notify.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:local on-chain:true
 service NotificationService {

--- a/proto/cmp/services/partner/v3/partner_configuration.proto
+++ b/proto/cmp/services/partner/v3/partner_configuration.proto
@@ -33,9 +33,9 @@ message GetPartnerConfigurationResponse {
 
 // Get Partner Configuration Service
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v2/partner_configuration.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v3/partner_configuration.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v2/partner_configuration.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v3/partner_configuration.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:local on-chain:true
 service GetPartnerConfigurationService {

--- a/proto/cmp/services/partner/v4/partner_configuration.proto
+++ b/proto/cmp/services/partner/v4/partner_configuration.proto
@@ -33,9 +33,9 @@ message GetPartnerConfigurationResponse {
 
 // Get Partner Configuration Service
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v2/partner_configuration.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v4/partner_configuration.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v2/partner_configuration.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/partner/v4/partner_configuration.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:local on-chain:true
 service GetPartnerConfigurationService {

--- a/proto/cmp/services/ping/v2/ping.proto
+++ b/proto/cmp/services/ping/v2/ping.proto
@@ -42,9 +42,9 @@ message PingResponse {
 
 // The Ping Service definition
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/ping/v1/ping.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/ping/v2/ping.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/ping/v1/ping.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/ping/v2/ping.proto.dot.svg)
 //
 /// @custom:cmp-service type:core routing:p2p on-chain:false
 service PingService {

--- a/proto/cmp/services/seat_map/v4/availability.proto
+++ b/proto/cmp/services/seat_map/v4/availability.proto
@@ -123,9 +123,9 @@ message SeatMapAvailabilityResponse {
 //
 // Service is used to request the seat map availability data for a given map ID
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v3/availability.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v4/availability.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v3/availability.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v4/availability.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service SeatMapAvailabilityService {

--- a/proto/cmp/services/seat_map/v4/seat_map.proto
+++ b/proto/cmp/services/seat_map/v4/seat_map.proto
@@ -56,9 +56,9 @@ message SeatMapResponse {
 
 // Service for requesting seat map data for a given map ID
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v3/seat_map.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v4/seat_map.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v3/seat_map.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/seat_map/v4/seat_map.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service SeatMapService {

--- a/proto/cmp/services/transport/v3/search_parameters_types.proto
+++ b/proto/cmp/services/transport/v3/search_parameters_types.proto
@@ -9,9 +9,9 @@ import "cmp/types/v3/price.proto";
 
 // Transport Search Parameters
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_parameters_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/search_parameters_types.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_parameters_types.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/search_parameters_types.proto.dot.svg)
 message TransportSearchParameters {
   // Specify one or more type codes to be included in the search response
   // Ex: code "EW" number "1234" of the type "IATA"

--- a/proto/cmp/services/transport/v4/list.proto
+++ b/proto/cmp/services/transport/v4/list.proto
@@ -29,9 +29,9 @@ message TransportProductListResponse {
 
 // This service is used to get a product list for transportation.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/list.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v4/list.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/list.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v4/list.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service TransportProductListService {

--- a/proto/cmp/services/transport/v4/search.proto
+++ b/proto/cmp/services/transport/v4/search.proto
@@ -81,9 +81,9 @@ message TransportSearchResponse {
 // Takes `TransportSearchRequest` message type and returns `TransportSearchResponse`
 // message type.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/search.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v4/search.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/search.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v4/search.proto.dot.svg)
 //
 /// @custom:cmp-service type:product routing:p2p on-chain:false
 service TransportSearchService {

--- a/proto/cmp/services/transport/v4/search_parameters_types.proto
+++ b/proto/cmp/services/transport/v4/search_parameters_types.proto
@@ -10,9 +10,9 @@ import "cmp/types/v4/time.proto";
 
 // Transport Search Parameters
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_parameters_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v4/search_parameters_types.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v2/search_parameters_types.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v4/search_parameters_types.proto.dot.svg)
 message TransportSearchParameters {
   // Specify one or more type codes to be included in the search response
   // Ex: code "EW" number "1234" of the type "IATA"

--- a/proto/cmp/services/transport/v4/search_query_types.proto
+++ b/proto/cmp/services/transport/v4/search_query_types.proto
@@ -16,9 +16,9 @@ import "cmp/types/v4/traveller.proto";
 // - 2 trips in trips: Roundtrip journey from PMI to BCN and then BCN to PMI.
 // - 3 trips in trips: PMI->BCN + BCN->BER + BER->PMI (1 two legged flight (connection) and 1 direct (return) flight)
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/search_query_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v4/search_query_types.proto.dot.xs.svg)
 // [Open Message
-// Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/search_query_types.proto.dot.svg)
+// Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v4/search_query_types.proto.dot.svg)
 message TransportSearchQuery {
   // ID
   uint32 query_id = 1;

--- a/proto/cmp/services/transport/v4/search_result_types.proto
+++ b/proto/cmp/services/transport/v4/search_result_types.proto
@@ -14,9 +14,9 @@ import "cmp/types/v4/rate.proto";
 
 // Transport search result
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/search_result_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v4/search_result_types.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/search_result_types.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v4/search_result_types.proto.dot.svg)
 message TransportSearchResult {
   // Unique result ID
   uint32 result_id = 1;

--- a/proto/cmp/services/transport/v4/trip_types.proto
+++ b/proto/cmp/services/transport/v4/trip_types.proto
@@ -15,9 +15,9 @@ import "google/protobuf/timestamp.proto";
 
 // This message type represents a one way trip, either travelling or returning.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/trip_types.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v4/trip_types.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v3/trip_types.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/transport/v4/trip_types.proto.dot.svg)
 message TripExtended {
   // Trip supplier code
   cmp.types.v4.SupplierProductCode supplier_code = 1 [(buf.validate.field).required = true];

--- a/proto/cmp/types/v1/credit_card.proto
+++ b/proto/cmp/types/v1/credit_card.proto
@@ -4,6 +4,11 @@ package cmp.types.v1;
 
 import "cmp/types/v1/date.proto";
 
+// Credit card definition
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/credit_card.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/credit_card.proto.dot.svg)
 message CreditCard {
   // A creditcard should be stored as a string to facilitate cards that have leading
   // zeros, but also to allow for spaces or dashes for readability, like for example

--- a/proto/cmp/types/v1/localized.proto
+++ b/proto/cmp/types/v1/localized.proto
@@ -4,6 +4,11 @@ package cmp.types.v1;
 
 import "cmp/types/v1/language.proto";
 
+// Localized string definition
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/localized.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/localized.proto.dot.svg)
 message LocalizedString {
   string text = 1;
   cmp.types.v1.Language language = 2;

--- a/proto/cmp/types/v1/loyalty_program.proto
+++ b/proto/cmp/types/v1/loyalty_program.proto
@@ -6,9 +6,9 @@ import "cmp/types/v1/link.proto";
 
 // Loyalty Program
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/loyalty_program.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/loyalty_program.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/loyalty_program.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/loyalty_program.proto.dot.svg)
 message LoyaltyProgram {
   // In case of an off-chain loyalty program, this is the id of the loyalty program in loyalty system
   oneof loyalty_id {

--- a/proto/cmp/types/v1/payment.proto
+++ b/proto/cmp/types/v1/payment.proto
@@ -6,6 +6,10 @@ import "cmp/types/v1/credit_card.proto";
 
 // Additional payment info message with currently only a single field of
 // `CreditCard` message type.
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/payment.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/payment.proto.dot.svg)
 message AdditionalPaymentInfo {
   cmp.types.v1.CreditCard credit_card = 1;
 }

--- a/proto/cmp/types/v1/price_type.proto
+++ b/proto/cmp/types/v1/price_type.proto
@@ -11,6 +11,11 @@ enum ChargeType {
   CHARGE_TYPE_PER_UNIT = 3;
 }
 
+// Price Type definitions
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/price_type.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/price_type.proto.dot.svg)
 enum PriceType {
   PRICE_TYPE_UNSPECIFIED = 0;
   PRICE_TYPE_BASE_RATE = 1;

--- a/proto/cmp/types/v1/pubkey.proto
+++ b/proto/cmp/types/v1/pubkey.proto
@@ -2,6 +2,11 @@ syntax = "proto3";
 
 package cmp.types.v1;
 
+// Public Key definitions
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/pubkey.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/pubkey.proto.dot.svg)
 message PublicKey {
   string key = 1;
 }

--- a/proto/cmp/types/v1/travel_type.proto
+++ b/proto/cmp/types/v1/travel_type.proto
@@ -2,6 +2,11 @@ syntax = "proto3";
 
 package cmp.types.v1;
 
+// Travel Type definitions
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/travel_type.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/travel_type.proto.dot.svg)
 enum TravelType {
   TRAVEL_TYPE_UNSPECIFIED = 0;
   TRAVEL_TYPE_LEISURE = 1;

--- a/proto/cmp/types/v3/evm_address.proto
+++ b/proto/cmp/types/v3/evm_address.proto
@@ -5,6 +5,10 @@ package cmp.types.v3;
 // Address type that represents an EVM address in hex format
 //
 // Example: "0x1234567890abcdef1234567890abcdef12345678"
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v3/evm_address.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v3/evm_address.proto.dot.svg)
 message EVMAddress {
   string address = 1;
 }

--- a/proto/cmp/types/v3/evm_transaction.proto
+++ b/proto/cmp/types/v3/evm_transaction.proto
@@ -5,6 +5,10 @@ package cmp.types.v3;
 // This represents an EVM transaction ID in hex format
 //
 // Example: "0xeb8d83e82ff50b27ab9287cd84e1b55a39b30377e68203fb74837aa35c489924"
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v3/evm_transaction.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v3/evm_transaction.proto.dot.svg)
 message EVMTransactionID {
   string hash = 1;
 }

--- a/proto/cmp/types/v3/partner.proto
+++ b/proto/cmp/types/v3/partner.proto
@@ -7,9 +7,9 @@ import "cmp/types/v3/token.proto";
 
 // ### Partner message type
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/partner.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v3/partner.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/partner.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v3/partner.proto.dot.svg)
 message Partner {
   // Short name of the partner. Ex: Chain4Travel
   string short_name = 1;

--- a/proto/cmp/types/v4/address.proto
+++ b/proto/cmp/types/v4/address.proto
@@ -7,9 +7,9 @@ import "cmp/types/v4/location.proto";
 
 // This type represents an address for places like a home or hotel etc.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/address.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/address.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/address.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/address.proto.dot.svg)
 message Address {
   string line_1 = 1 [(buf.validate.field).string = {
     min_len: 1

--- a/proto/cmp/types/v4/airport.proto
+++ b/proto/cmp/types/v4/airport.proto
@@ -7,6 +7,10 @@ import "buf/validate/validate.proto";
 // Type definition for an airport code which can be:
 // * IATA for code length 3
 // * ICAO for code length 4
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/airport.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/airport.proto.dot.svg)
 message AirportCode {
   string code = 1 [(buf.validate.field).string = {
     min_len: 3

--- a/proto/cmp/types/v4/contact_info.proto
+++ b/proto/cmp/types/v4/contact_info.proto
@@ -14,9 +14,9 @@ import "cmp/types/v4/phone.proto";
 //
 // This message is designed for general use wherever contact information is needed.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/contact_info.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/contact_info.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/contact_info.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/contact_info.proto.dot.svg)
 message ContactInfo {
   // Optional. A list of physical or postal addresses.
   //

--- a/proto/cmp/types/v4/credit_card.proto
+++ b/proto/cmp/types/v4/credit_card.proto
@@ -15,6 +15,10 @@ import "cmp/types/v4/date.proto";
 //   strong encryption, tokenization).
 // - The CVC (Card Verification Code) **MUST NEVER BE STORED** after transaction
 //   authorization.
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/credit_card.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/credit_card.proto.dot.svg)
 message CreditCard {
   // The primary account number (PAN) of the credit card.
   //

--- a/proto/cmp/types/v4/delivery.proto
+++ b/proto/cmp/types/v4/delivery.proto
@@ -6,9 +6,9 @@ import "buf/validate/validate.proto";
 
 // Delivery Formats and Methods
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/delivery.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/delivery.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/delivery.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/delivery.proto.dot.svg)
 message Delivery {
   cmp.types.v4.DeliveryFormat format = 1 [(buf.validate.field).enum = {
     defined_only: true

--- a/proto/cmp/types/v4/evm_address.proto
+++ b/proto/cmp/types/v4/evm_address.proto
@@ -7,6 +7,10 @@ import "buf/validate/validate.proto";
 // Address type that represents an EVM address in hex format
 //
 // Example: "0x1234567890abcdef1234567890abcdef12345678"
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/evm_address.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/evm_address.proto.dot.svg)
 message EVMAddress {
   string address = 1 [(buf.validate.field).string = {
     pattern: "^0x[0-9a-fA-F]{40}$" // 0x followed by exactly 40 hex characters

--- a/proto/cmp/types/v4/evm_transaction.proto
+++ b/proto/cmp/types/v4/evm_transaction.proto
@@ -7,6 +7,10 @@ import "buf/validate/validate.proto";
 // This represents an EVM transaction ID in hex format
 //
 // Example: "0xeb8d83e82ff50b27ab9287cd84e1b55a39b30377e68203fb74837aa35c489924"
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/evm_transaction.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/evm_transaction.proto.dot.svg)
 message EVMTransactionID {
   string hash = 1 [(buf.validate.field).string = {
     pattern: "^0x[0-9a-fA-F]{64}$" // Starts with 0x followed by 64 hex characters

--- a/proto/cmp/types/v4/localized.proto
+++ b/proto/cmp/types/v4/localized.proto
@@ -9,6 +9,10 @@ import "cmp/types/v1/language.proto";
 //
 // This message is used to provide textual content, such as names or short labels,
 // that need to be displayed in multiple languages.
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/localized.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/localized.proto.dot.svg)
 message LocalizedString {
   // The actual text content of the string.
   string text = 1 [(buf.validate.field).string = {

--- a/proto/cmp/types/v4/partner.proto
+++ b/proto/cmp/types/v4/partner.proto
@@ -10,9 +10,9 @@ import "cmp/types/v4/token.proto";
 
 // ### Partner message type
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/partner.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/partner.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v2/partner.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/partner.proto.dot.svg)
 message Partner {
   // Short name of the partner. Ex: Chain4Travel
   string short_name = 1 [(buf.validate.field).string = {

--- a/proto/cmp/types/v4/price_types.proto
+++ b/proto/cmp/types/v4/price_types.proto
@@ -13,6 +13,11 @@ enum ChargeType {
   CHARGE_TYPE_PER_UNIT = 3;
 }
 
+// Price Type definitions
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/price_types.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/price_types.proto.dot.svg)
 enum PriceType {
   PRICE_TYPE_UNSPECIFIED = 0;
   PRICE_TYPE_BASE_RATE = 1;

--- a/proto/cmp/types/v4/pubkey.proto
+++ b/proto/cmp/types/v4/pubkey.proto
@@ -4,6 +4,11 @@ package cmp.types.v4;
 
 import "buf/validate/validate.proto";
 
+// Public Key definitions
+//
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/pubkey.proto.dot.xs.svg)
+//
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/pubkey.proto.dot.svg)
 message PublicKey {
   string key = 1 [(buf.validate.field).string = {
     min_len: 32

--- a/proto/cmp/types/v4/redemption.proto
+++ b/proto/cmp/types/v4/redemption.proto
@@ -4,9 +4,9 @@ package cmp.types.v4;
 
 // Redemption Methods
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/redemption.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/redemption.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/redemption.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/redemption.proto.dot.svg)
 enum RedemptionMethod {
   REDEMPTION_METHOD_UNSPECIFIED = 0;
   REDEMPTION_METHOD_DIGITAL = 1;

--- a/proto/cmp/types/v4/sorting.proto
+++ b/proto/cmp/types/v4/sorting.proto
@@ -8,9 +8,9 @@ import "buf/validate/validate.proto";
 //
 // This is being used in requests to specify the sorting required in the response.
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/sorting.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/sorting.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/sorting.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/sorting.proto.dot.svg)
 message Sorting {
   cmp.types.v4.SortingType sorting_type = 1 [(buf.validate.field).enum = {defined_only: true}];
   cmp.types.v4.SortingOrder sorting_order = 2 [(buf.validate.field).enum = {defined_only: true}];

--- a/proto/cmp/types/v4/time.proto
+++ b/proto/cmp/types/v4/time.proto
@@ -13,9 +13,9 @@ import "buf/validate/validate.proto";
 //   Time morning_meeting = Time{hours: 9, minutes: 30};  // 9:30 AM
 //   Time end_of_day = Time{hours: 17, minutes: 0};       // 5:00 PM
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/time.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/time.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/time.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/time.proto.dot.svg)
 message Time {
   // Hours component in 24-hour format
   // Valid range: 0-23 (0 = midnight, 12 = noon, 23 = 11 PM)

--- a/proto/cmp/types/v4/travel_period.proto
+++ b/proto/cmp/types/v4/travel_period.proto
@@ -12,9 +12,9 @@ import "cmp/types/v4/dow.proto";
 // and flexible periods (where start_date and end_date form a window for a
 // trip of a duration specified by `los`).
 //
-// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/travel_period.proto.dot.xs.svg)
+// ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/travel_period.proto.dot.xs.svg)
 //
-// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v1/travel_period.proto.dot.svg)
+// [Open Message Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/types/v4/travel_period.proto.dot.svg)
 message TravelPeriod {
   option (buf.validate.message).cel = {
     id: "end_date_after_or_on_start_date"

--- a/scripts/verify_diagram_links.sh
+++ b/scripts/verify_diagram_links.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# verify that all diagram links in the proto files are valid meaning that they
+# follow the expected pattern. If the url is actually reachable is not checked.
+# Also check if the url has the correct path in it based on the proto file path.
+ERROR=0
+
+BASEURL="https://storage.googleapis.com/docs-cmp-files/diagrams/"
+
+for file in $(find proto/ -name "*.proto"); do
+	#echo "Checking file: $file"
+	diagram_link_count=$(grep -Fc "(${BASEURL}${file}.dot.xs.svg)" "$file")
+	open_diagram_link_count=$(grep -Fc "(${BASEURL}${file}.dot.svg)" "$file")
+
+	if [ "$diagram_link_count" -ne 1 ] || [ "$open_diagram_link_count" -ne 1 ]; then
+		echo "Error: File '$file' does not contain the expected diagram links."
+		echo "Found $diagram_link_count diagram link(s) and $open_diagram_link_count open diagram link(s)."
+		ERROR=1
+	fi
+done
+
+if [ "$ERROR" -ne 0 ]; then
+	echo "One or more files have invalid diagram links."
+	exit 1
+else
+	echo "All diagram links are valid."
+	exit 0
+fi


### PR DESCRIPTION
* Replaced names and descriptions where applicable with the localized versions
* Moved the activity identifier `Activity` which was as separate message before into `ActivitySearchResult` as this was the only place where the identifier was used.
* Removed `schedule` from `ActivityUnit` as this is already defined in the static data.
* Removed `excluded` field from `ActivityService` as it doesn't make sense to list things which are not included.
* Aligned activity more with accommodation by splitting up the activity data and introducing a short list. 
* Replaced several strings with enums.