### PR TITLE
Response validity

### DIFF
--- a/proto/cmp/services/accommodation/v4/search.proto
+++ b/proto/cmp/services/accommodation/v4/search.proto
@@ -135,7 +135,7 @@ message AccommodationSearchResponse {
   cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Search_id to be used in subsequent requests like the "Validation Request".
-  cmp.types.v4.UUID search_id = 2 [(buf.validate.field).required = true];
+  cmp.types.v4.ExpiringUUID search_id = 2 [(buf.validate.field).required = true];
 
   // Unique combinations of bookable search results
   repeated cmp.services.accommodation.v4.AccommodationSearchResult results = 3 [(buf.validate.field).repeated = {

--- a/proto/cmp/services/activity/v4/search.proto
+++ b/proto/cmp/services/activity/v4/search.proto
@@ -134,7 +134,7 @@ message ActivitySearchResponse {
   cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Search_id to be used in subsequent requests like the "Validation Request".
-  cmp.types.v4.UUID search_id = 2 [(buf.validate.field).required = true];
+  cmp.types.v4.ExpiringUUID search_id = 2 [(buf.validate.field).required = true];
 
   // Unique combinations of bookable search results, each identified by a result_id
   // that needs to be carried through to the validate request.

--- a/proto/cmp/services/activity/v4/search_result_types.proto
+++ b/proto/cmp/services/activity/v4/search_result_types.proto
@@ -27,7 +27,7 @@ message ActivitySearchResult {
   // See: ActivityExtendedInfo.units.code
   string unit_code = 3 [(buf.validate.field).string.max_bytes = 512];
 
-  // The code must match one of the defined units provided in the ProductList
+  // The code must match one of the defined services provided in the ProductList
   // and ProductInfo message.
   // See: ActivityExtendedInfo.services.code
   string service_code = 4 [(buf.validate.field).string.max_bytes = 512];

--- a/proto/cmp/services/book/v4/validate.proto
+++ b/proto/cmp/services/book/v4/validate.proto
@@ -23,7 +23,7 @@ message ValidationResponse {
   cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Unique validation ID which can be used in the subsequent mint request.
-  cmp.types.v4.UUID validation_id = 2 [(buf.validate.field).required = true];
+  cmp.types.v4.ExpiringUUID validation_id = 2 [(buf.validate.field).required = true];
 
   // The object which has been validated in this response.
   // This describes the product or service to be validated resulting from a previous search.
@@ -78,7 +78,7 @@ message ServiceFactSelection {
 // and therefore needs to be reflected in the `price_detail` of the `ValidationResponse`.
 message ValidationObject {
   // Search result identifier which uniquely identifies a certain search and a result in that search.
-  cmp.types.v4.SearchIdentifier search_identifier = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SearchResultIdentifier search_result_identifier = 1 [(buf.validate.field).required = true];
 
   // Optional seat selection for the validation.
   // Only applicable for products with (selectable) seats.

--- a/proto/cmp/services/seat_map/v4/availability.proto
+++ b/proto/cmp/services/seat_map/v4/availability.proto
@@ -102,7 +102,7 @@ message SeatMapAvailabilityRequest {
     //
     // Example: For requesting seat availability for search results. In this case,
     // booking has not happened yet.
-    cmp.types.v4.SearchIdentifier search_identifier = 3;
+    cmp.types.v4.SearchResultIdentifier search_result_identifier = 3;
   }
 }
 

--- a/proto/cmp/services/transport/v4/search.proto
+++ b/proto/cmp/services/transport/v4/search.proto
@@ -44,7 +44,7 @@ message TransportSearchResponse {
   cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Search_id to be used in subsequent requests like the "Validation Request".
-  cmp.types.v4.UUID search_id = 2 [(buf.validate.field).required = true];
+  cmp.types.v4.ExpiringUUID search_id = 2 [(buf.validate.field).required = true];
 
   // Content source types for this search request.
   //

--- a/proto/cmp/services/transport/v4/search_result_types.proto
+++ b/proto/cmp/services/transport/v4/search_result_types.proto
@@ -7,7 +7,6 @@ import "cmp/services/transport/v4/trip_types.proto";
 import "cmp/types/v4/bookability.proto";
 import "cmp/types/v4/cancel_policy.proto";
 import "cmp/types/v4/change_policy.proto";
-import "cmp/types/v4/datetime_range.proto";
 import "cmp/types/v4/link.proto";
 import "cmp/types/v4/price.proto";
 import "cmp/types/v4/rate.proto";
@@ -68,24 +67,13 @@ message TransportSearchResult {
   // Status of the result, whether it is immediately bookable or not
   cmp.types.v4.Bookability bookability = 9 [(buf.validate.field).required = true];
 
-  // FIXME: Do we also need validity (below) in accommodation/activity?
-
-  // Validity of the search option.
-  //
-  // `DateTimeRange` type with `start_date` and `end_date` in which the option can
-  // be booked. If the start_date is omitted, the offer can be booked until the
-  // end-date.
-  //
-  // FIXME: Clarify if datetime range is needed here or just a end_date timestamp is sufficient!
-  cmp.types.v4.DateTimeRange validity = 10 [(buf.validate.field).required = true];
-
   // Cancel Policy
-  cmp.types.v4.CancelPolicy cancel_policy = 11 [(buf.validate.field).required = true];
+  cmp.types.v4.CancelPolicy cancel_policy = 10 [(buf.validate.field).required = true];
 
   // Change Policy
-  cmp.types.v4.ChangePolicy change_policy = 12;
+  cmp.types.v4.ChangePolicy change_policy = 11;
 
   // Observations
   // FIXME: Clarify what this is used for?
-  string observations = 13 [(buf.validate.field).string.max_bytes = 512];
+  string observations = 12 [(buf.validate.field).string.max_bytes = 512];
 }

--- a/proto/cmp/types/v4/common.proto
+++ b/proto/cmp/types/v4/common.proto
@@ -32,7 +32,6 @@ package cmp.types.v4;
 
 import "buf/validate/validate.proto";
 import "cmp/types/v4/evm_address.proto";
-import "google/protobuf/timestamp.proto";
 
 // Header provides common metadata for CMP messages.
 //

--- a/proto/cmp/types/v4/common.proto
+++ b/proto/cmp/types/v4/common.proto
@@ -32,6 +32,7 @@ package cmp.types.v4;
 
 import "buf/validate/validate.proto";
 import "cmp/types/v4/evm_address.proto";
+import "google/protobuf/timestamp.proto";
 
 // Header provides common metadata for CMP messages.
 //
@@ -113,6 +114,14 @@ message ResponseHeader {
   // response, such as informational messages, warnings, or specific errors.
   // In case of a failure, alerts must provide insights into the issue.
   repeated cmp.types.v4.Alert alerts = 3 [(buf.validate.field).repeated = {max_items: 25}];
+
+  // Validity of the response.
+  // This applies to all responses which are part of a message chain
+  // like Search -> Validate -> Mint.
+  // The field describes the point in time the response is becoming invalid
+  // to proceed in the process chain and is used to guard the responding system
+  // from having to store everything indefinitely.
+  google.protobuf.Timestamp valid_until = 4;
 }
 
 // Alert provides detailed feedback, which can be an error, warning, or

--- a/proto/cmp/types/v4/common.proto
+++ b/proto/cmp/types/v4/common.proto
@@ -114,14 +114,6 @@ message ResponseHeader {
   // response, such as informational messages, warnings, or specific errors.
   // In case of a failure, alerts must provide insights into the issue.
   repeated cmp.types.v4.Alert alerts = 3 [(buf.validate.field).repeated = {max_items: 25}];
-
-  // Validity of the response.
-  // This applies to all responses which are part of a message chain
-  // like Search -> Validate -> Mint.
-  // The field describes the point in time the response is becoming invalid
-  // to proceed in the process chain and is used to guard the responding system
-  // from having to store everything indefinitely.
-  google.protobuf.Timestamp valid_until = 4;
 }
 
 // Alert provides detailed feedback, which can be an error, warning, or

--- a/proto/cmp/types/v4/search.proto
+++ b/proto/cmp/types/v4/search.proto
@@ -90,9 +90,9 @@ message SearchParameters {
   }];
 }
 
-// Search identifier
-message SearchIdentifier {
-  // Search ID that is returned in the search response message
+// Identifier for an individual result within a specific search.
+message SearchResultIdentifier {
+  // Search ID that is returned in the search response message.
   cmp.types.v4.UUID search_id = 1 [(buf.validate.field).required = true];
 
   // Result ID that is returned by `result_id` field of the search result

--- a/proto/cmp/types/v4/uuid.proto
+++ b/proto/cmp/types/v4/uuid.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package cmp.types.v4;
 
 import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
 
 // This must be a UUID according to RFC 4122 standard.
 //
@@ -12,4 +13,16 @@ import "buf/validate/validate.proto";
 message UUID {
   // This ensures that value is a valid [RFC 4122](https://datatracker.ietf.org/doc/html/rfc4122#section-4.1.2)
   string value = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// Generic timed UUID with an explicit expiration for follow up processes using this ID.
+message ExpiringUUID {
+  // Unique ID
+  cmp.types.v4.UUID id = 1 [(buf.validate.field).required = true];
+
+  // Validity of the ID. When the timestamp is hit following requests using this
+  // ID will fail as it is no longer valid. For example, a search ID
+  // may only be valid for 15 minutes after which it cannot be used anymore for
+  // validation requests.
+  google.protobuf.Timestamp expiration = 2 [(buf.validate.field).required = true];
 }


### PR DESCRIPTION
* Moving validity of the result from individual transport result into a new type expressing an expireable UUID
* Using the new type `ExpiringUUID` for search and validate responses to express that these IDs are expiring at a certain point