### PR TITLE
Proto-Valid Error Responses

### DIFF
--- a/proto/cmp/services/accommodation/v4/info.proto
+++ b/proto/cmp/services/accommodation/v4/info.proto
@@ -34,10 +34,9 @@ message AccommodationProductInfoRequest {
   }];
 }
 
-// Respond detailed (static) information about accommodations.
-message AccommodationProductInfoResponse {
-  // Common response header used in every response.
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+message AccommodationProductInfoSuccessResponse {
+  // Common response header used in every successful response.
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // The list of properties which should match the requested supplier codes.
   // In case the supplier is unable to return all requested properties, it should
@@ -49,6 +48,20 @@ message AccommodationProductInfoResponse {
     min_items: 0
     max_items: 100 // Default max items
   }];
+}
+
+message AccommodationProductInfoErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+// Respond detailed (static) information about accommodations.
+message AccommodationProductInfoResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.accommodation.v4.AccommodationProductInfoSuccessResponse success_response = 1;
+    cmp.services.accommodation.v4.AccommodationProductInfoErrorResponse error_response = 2;
+  }
 }
 
 // Accommodation product info service definition

--- a/proto/cmp/services/accommodation/v4/list.proto
+++ b/proto/cmp/services/accommodation/v4/list.proto
@@ -23,16 +23,29 @@ message AccommodationProductListRequest {
   }];
 }
 
-// Respond basic (static) information about accommodations for mapping purposes.
-message AccommodationProductListResponse {
-  // Common response header used in every response.
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+message AccommodationProductListSuccessResponse {
+  // Common response header used in every successful response.
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // The list of properties which should match the requested supplier codes.
   // In case the supplier is unable to return all requested properties, it should
   // return a warning in the response. This can happen if a property is no longer
   // a valid product.
   repeated cmp.services.accommodation.v4.Property properties = 2;
+}
+
+message AccommodationProductListErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+// Respond basic (static) information about accommodations for mapping purposes.
+message AccommodationProductListResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.accommodation.v4.AccommodationProductListSuccessResponse success_response = 1;
+    cmp.services.accommodation.v4.AccommodationProductListErrorResponse error_response = 2;
+  }
 }
 
 // Accommodation product list service definition.

--- a/proto/cmp/services/accommodation/v4/search.proto
+++ b/proto/cmp/services/accommodation/v4/search.proto
@@ -94,16 +94,9 @@ message AccommodationSearchRequest {
   }];
 }
 
-// The `Accommodation Search Response` message type facilitates the response for
-// accommodations like hotel and holiday home searches within the platform.
-//
-// In the response a search_id must be included and a search_option_id for every
-// bookable option responded. Included, compulsory and optional services can be
-// included. A simple "free cancellation upto" can be set or full cancellation
-// policies can be included.
-message AccommodationSearchResponse {
-  // Common response header used in every response.
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+message AccommodationSearchSuccessResponse {
+  // Common response header used in every successful response.
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Search_id to be used in subsequent requests like the "Validation Request".
   cmp.types.v4.ExpiringUUID search_id = 2 [(buf.validate.field).required = true];
@@ -117,9 +110,29 @@ message AccommodationSearchResponse {
   // Global definition of the travellers for all results to be used via the
   // traveller_id in each unit.
   repeated cmp.types.v4.BasicTraveller travellers = 4 [(buf.validate.field).repeated = {
-    min_items: 0
+    min_items: 1
     max_items: 15
   }];
+}
+
+message AccommodationSearchErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+// The `Accommodation Search Response` message type facilitates the response for
+// accommodations like hotel and holiday home searches within the platform.
+//
+// In the response a search_id must be included and a search_option_id for every
+// bookable option responded. Included, compulsory and optional services can be
+// included. A simple "free cancellation upto" can be set or full cancellation
+// policies can be included.
+message AccommodationSearchResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.accommodation.v4.AccommodationSearchSuccessResponse success_response = 1;
+    cmp.services.accommodation.v4.AccommodationSearchErrorResponse error_response = 2;
+  }
 }
 
 // Service definition for Accommodation search

--- a/proto/cmp/services/accommodation/v4/short_list.proto
+++ b/proto/cmp/services/accommodation/v4/short_list.proto
@@ -19,15 +19,28 @@ message AccommodationProductShortListRequest {
   google.protobuf.Timestamp modified_after = 2;
 }
 
-// Respond a list of modified accommodations.
-message AccommodationProductShortListResponse {
-  // Common response header used in every response.
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+message AccommodationProductShortListSuccessResponse {
+  // Common response header used in every successful response.
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Supplier codes and status for the products that are modified after the timestamp
   // in the `AccommodationProductShortListRequest`. If there are no changes, the list
   // will be empty.
   repeated cmp.services.accommodation.v4.PropertyShortListItem property_short_list_items = 2;
+}
+
+message AccommodationProductShortListErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+// Respond a list of modified accommodations.
+message AccommodationProductShortListResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.accommodation.v4.AccommodationProductShortListSuccessResponse success_response = 1;
+    cmp.services.accommodation.v4.AccommodationProductShortListErrorResponse error_response = 2;
+  }
 }
 
 // Accommodation product short list service definition. This is an alternative

--- a/proto/cmp/services/activity/v4/info.proto
+++ b/proto/cmp/services/activity/v4/info.proto
@@ -27,15 +27,28 @@ message ActivityProductInfoRequest {
   }];
 }
 
-message ActivityProductInfoResponse {
+message ActivityProductInfoSuccessResponse {
   // Message header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Product list: Activities
   repeated cmp.services.activity.v4.ActivityExtendedInfo activities = 2 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100 // Default max items
   }];
+}
+
+message ActivityProductInfoErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message ActivityProductInfoResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.activity.v4.ActivityProductInfoSuccessResponse success_response = 1;
+    cmp.services.activity.v4.ActivityProductInfoErrorResponse error_response = 2;
+  }
 }
 
 // Activity product info service definition

--- a/proto/cmp/services/activity/v4/list.proto
+++ b/proto/cmp/services/activity/v4/list.proto
@@ -22,14 +22,27 @@ message ActivityProductListRequest {
   }];
 }
 
-message ActivityProductListResponse {
+message ActivityProductListSuccessResponse {
   // Message header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // List of basic identifiers and informations for activities
   // Used to decide whether to pull the full information for mapping purposes
   // With a ActivityProductInfoRequest.
   repeated cmp.services.activity.v4.ActivityInfo activities = 2;
+}
+
+message ActivityProductListErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message ActivityProductListResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.activity.v4.ActivityProductListSuccessResponse success_response = 1;
+    cmp.services.activity.v4.ActivityProductListErrorResponse error_response = 2;
+  }
 }
 
 // This service is used to get a product list for activities.

--- a/proto/cmp/services/activity/v4/search.proto
+++ b/proto/cmp/services/activity/v4/search.proto
@@ -128,10 +128,10 @@ message ActivitySearchRequest {
   }
 }
 
-message ActivitySearchResponse {
+message ActivitySearchSuccessResponse {
   // Message header. Contains API version, message info string and end user wallet
   // address.
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Search_id to be used in subsequent requests like the "Validation Request".
   cmp.types.v4.ExpiringUUID search_id = 2 [(buf.validate.field).required = true];
@@ -148,6 +148,19 @@ message ActivitySearchResponse {
     min_items: 1
     max_items: 15
   }];
+}
+
+message ActivitySearchErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message ActivitySearchResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.activity.v4.ActivitySearchSuccessResponse success_response = 1;
+    cmp.services.activity.v4.ActivitySearchErrorResponse error_response = 2;
+  }
 }
 
 // Activity Search Service

--- a/proto/cmp/services/activity/v4/short_list.proto
+++ b/proto/cmp/services/activity/v4/short_list.proto
@@ -19,15 +19,28 @@ message ActivityProductShortListRequest {
   google.protobuf.Timestamp modified_after = 2;
 }
 
-// Respond a list of modified activities.
-message ActivityProductShortListResponse {
-  // Common response header used in every response.
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+message ActivityProductShortListSuccessResponse {
+  // Common response header used in every successful response.
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Supplier codes and status for the products that are modified after the timestamp
   // in the `ActivityProductShortListRequest`. If there are no changes, the list
   // will be empty.
   repeated cmp.services.activity.v4.ActivityShortListItem activity_short_list_items = 2;
+}
+
+message ActivityProductShortListErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+// Respond a list of modified activities.
+message ActivityProductShortListResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.activity.v4.ActivityProductShortListSuccessResponse success_response = 1;
+    cmp.services.activity.v4.ActivityProductShortListErrorResponse error_response = 2;
+  }
 }
 
 // Activity product short list service definition. This is an alternative

--- a/proto/cmp/services/book/v4/mint.proto
+++ b/proto/cmp/services/book/v4/mint.proto
@@ -56,9 +56,9 @@ message MintRequest {
   cmp.types.v4.Price expected_price = 9 [(buf.validate.field).required = true];
 }
 
-message MintResponse {
+message MintSuccessResponse {
   // Common header which is used in every response.
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Unique mint ID for the minting operation.
   cmp.types.v4.UUID mint_id = 2 [(buf.validate.field).required = true];
@@ -117,6 +117,19 @@ message MintResponse {
   // of the blockchain would be undermined. Disputes will reoccur. This kind of flows
   // are strongly discouraged.
   bool cancellable = 12;
+}
+
+message MintErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message MintResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.book.v4.MintSuccessResponse success_response = 1;
+    cmp.services.book.v4.MintErrorResponse error_response = 2;
+  }
 }
 
 // ![Diagram](https://storage.googleapis.com/docs-cmp-files/diagrams/proto/cmp/services/book/v4/mint.proto.dot.xs.svg)

--- a/proto/cmp/services/book/v4/validate.proto
+++ b/proto/cmp/services/book/v4/validate.proto
@@ -18,9 +18,9 @@ message ValidationRequest {
   cmp.services.book.v4.ValidationObject validation_object = 2 [(buf.validate.field).required = true];
 }
 
-message ValidationResponse {
+message ValidationSuccessResponse {
   // Common header which is used in every response.
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Unique validation ID which can be used in the subsequent mint request.
   cmp.types.v4.ExpiringUUID validation_id = 2 [(buf.validate.field).required = true];
@@ -37,6 +37,19 @@ message ValidationResponse {
   // Additionally any selected optional services like seat selections or service fact selections
   // must be reflected in this total price and the optional breakdown.
   cmp.types.v4.TotalPrice total_price = 4 [(buf.validate.field).required = true];
+}
+
+message ValidationErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message ValidationResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.book.v4.ValidationSuccessResponse success_response = 1;
+    cmp.services.book.v4.ValidationErrorResponse error_response = 2;
+  }
 }
 
 // Additional layer to allow for selecting seats in different segments.

--- a/proto/cmp/services/cancellation/v2/accept.proto
+++ b/proto/cmp/services/cancellation/v2/accept.proto
@@ -26,9 +26,9 @@ message AcceptCancellationRequest {
 }
 
 // Response for cancellation acceptance
-message AcceptCancellationResponse {
+message AcceptCancellationSuccessResponse {
   // Response header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Transaction ID on-chain for the cancellation proposal acceptance.
   // This transaction can be verified on-chain to:
@@ -36,4 +36,17 @@ message AcceptCancellationResponse {
   // 2. Validate the accepted refund amount
   // 3. Prevent disputes about acceptance terms
   cmp.types.v4.EVMTransactionID transaction_id = 2 [(buf.validate.field).required = true];
+}
+
+message AcceptCancellationErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message AcceptCancellationResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.cancellation.v2.AcceptCancellationSuccessResponse success_response = 1;
+    cmp.services.cancellation.v2.AcceptCancellationErrorResponse error_response = 2;
+  }
 }

--- a/proto/cmp/services/cancellation/v2/check.proto
+++ b/proto/cmp/services/cancellation/v2/check.proto
@@ -60,9 +60,9 @@ message CheckCancellationRequest {
 // - CONFIRM: Cancellation allowed, refund_amount shows what customer will receive
 // - REJECT: Cancellation denied, rejection_reason explains why
 // - ALREADY_CANCELLED: Booking was previously cancelled, no action needed
-message CheckCancellationResponse {
+message CheckCancellationSuccessResponse {
   // The response header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Echo of the booking token_id from the request for correlation
   uint64 token_id = 2;
@@ -109,6 +109,19 @@ message CheckCancellationResponse {
       expression: "this.status != cmp.services.cancellation.v2.CancellationCheckStatus.CANCELLATION_CHECK_STATUS_REJECT || this.rejection_reason != 0"
     }
   };
+}
+
+message CheckCancellationErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message CheckCancellationResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.cancellation.v2.CheckCancellationSuccessResponse success_response = 1;
+    cmp.services.cancellation.v2.CheckCancellationErrorResponse error_response = 2;
+  }
 }
 
 enum CancellationCheckStatus {

--- a/proto/cmp/services/cancellation/v2/counter.proto
+++ b/proto/cmp/services/cancellation/v2/counter.proto
@@ -31,9 +31,9 @@ message CounterCancellationRequest {
 }
 
 // Response for countering a cancellation
-message CounterCancellationResponse {
+message CounterCancellationSuccessResponse {
   // Response header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Transaction ID on-chain for the cancellation proposal counter.
   // This transaction can be verified on-chain to:
@@ -41,4 +41,17 @@ message CounterCancellationResponse {
   // 2. Validate the counter refund amount
   // 3. Prevent disputes about counter terms
   cmp.types.v4.EVMTransactionID transaction_id = 2 [(buf.validate.field).required = true];
+}
+
+message CounterCancellationErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message CounterCancellationResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.cancellation.v2.CounterCancellationSuccessResponse success_response = 1;
+    cmp.services.cancellation.v2.CounterCancellationErrorResponse error_response = 2;
+  }
 }

--- a/proto/cmp/services/cancellation/v2/finalize.proto
+++ b/proto/cmp/services/cancellation/v2/finalize.proto
@@ -23,9 +23,9 @@ message FinalizeCancellationRequest {
   cmp.types.v4.Price refund_amount = 3 [(buf.validate.field).required = true];
 }
 
-message FinalizeCancellationResponse {
+message FinalizeCancellationSuccessResponse {
   // The response header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Transaction ID on-chain for the cancellation proposal finalization. This
   // transaction proves the finalization of the cancellation proposal on-chain.
@@ -35,4 +35,17 @@ message FinalizeCancellationResponse {
   // 2. Validate the refund amount
   // 3. Prevent disputes about the cancellation terms
   cmp.types.v4.EVMTransactionID transaction_id = 2 [(buf.validate.field).required = true];
+}
+
+message FinalizeCancellationErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message FinalizeCancellationResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.cancellation.v2.FinalizeCancellationSuccessResponse success_response = 1;
+    cmp.services.cancellation.v2.FinalizeCancellationErrorResponse error_response = 2;
+  }
 }

--- a/proto/cmp/services/cancellation/v2/initiate.proto
+++ b/proto/cmp/services/cancellation/v2/initiate.proto
@@ -29,9 +29,9 @@ message InitiateCancellationRequest {
   }];
 }
 
-message InitiateCancellationResponse {
+message InitiateCancellationSuccessResponse {
   // The response header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Transaction ID on-chain for the cancellation proposal initiation. This
   // transaction proves the initiation of the cancellation proposal on-chain.
@@ -41,4 +41,17 @@ message InitiateCancellationResponse {
   // 2. Validate the refund amount
   // 3. Prevent disputes about the cancellation terms
   cmp.types.v4.EVMTransactionID transaction_id = 2 [(buf.validate.field).required = true];
+}
+
+message InitiateCancellationErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message InitiateCancellationResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.cancellation.v2.InitiateCancellationSuccessResponse success_response = 1;
+    cmp.services.cancellation.v2.InitiateCancellationErrorResponse error_response = 2;
+  }
 }

--- a/proto/cmp/services/cancellation/v2/reject.proto
+++ b/proto/cmp/services/cancellation/v2/reject.proto
@@ -27,9 +27,9 @@ message RejectCancellationRequest {
 }
 
 // Response for cancellation rejection
-message RejectCancellationResponse {
+message RejectCancellationSuccessResponse {
   // Response Header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Transaction ID on-chain for the cancellation proposal rejection.
   //
@@ -38,4 +38,17 @@ message RejectCancellationResponse {
   // 2. Validate the rejection reason
   // 3. Prevent disputes about the cancellation
   cmp.types.v4.EVMTransactionID transaction_id = 2 [(buf.validate.field).required = true];
+}
+
+message RejectCancellationErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message RejectCancellationResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.cancellation.v2.RejectCancellationSuccessResponse success_response = 1;
+    cmp.services.cancellation.v2.RejectCancellationErrorResponse error_response = 2;
+  }
 }

--- a/proto/cmp/services/cancellation/v2/withdraw.proto
+++ b/proto/cmp/services/cancellation/v2/withdraw.proto
@@ -27,9 +27,9 @@ message WithdrawCancellationRequest {
 }
 
 // Response for withdrawal of an active cancellation proposal
-message WithdrawCancellationResponse {
+message WithdrawCancellationSuccessResponse {
   // Response header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Transaction ID on-chain for withdrawing the cancellation proposal.
   //
@@ -38,4 +38,17 @@ message WithdrawCancellationResponse {
   // 2. Validate the accepted refund amount
   // 3. Prevent disputes about acceptance terms
   cmp.types.v4.EVMTransactionID transaction_id = 2 [(buf.validate.field).required = true];
+}
+
+message WithdrawCancellationErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message WithdrawCancellationResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.cancellation.v2.WithdrawCancellationSuccessResponse success_response = 1;
+    cmp.services.cancellation.v2.WithdrawCancellationErrorResponse error_response = 2;
+  }
 }

--- a/proto/cmp/services/claim/v2/claim_settlement_decision.proto
+++ b/proto/cmp/services/claim/v2/claim_settlement_decision.proto
@@ -46,10 +46,23 @@ message ClaimSettlementDecisionRequest {
   cmp.types.v4.PriceDetail amount = 8;
 }
 
-message ClaimSettlementDecisionResponse {
+message ClaimSettlementDecisionSuccessResponse {
   // Message header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Claim Message Response to respond with claim ids (processing, carrier and submission) and message status
   cmp.services.claim.v2.ClaimMessageResponse claim_message_response = 2;
+}
+
+message ClaimSettlementDecisionErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message ClaimSettlementDecisionResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.claim.v2.ClaimSettlementDecisionSuccessResponse success_response = 1;
+    cmp.services.claim.v2.ClaimSettlementDecisionErrorResponse error_response = 2;
+  }
 }

--- a/proto/cmp/services/claim/v2/claim_settlement_extra_info.proto
+++ b/proto/cmp/services/claim/v2/claim_settlement_extra_info.proto
@@ -33,10 +33,23 @@ message ClaimSettlementExtraInfoRequest {
   }];
 }
 
-message ClaimSettlementExtraInfoResponse {
+message ClaimSettlementExtraInfoSuccessResponse {
   // Message header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Claim Message Response to respond with claim ids (processing, carrier and submission) and message status
   cmp.services.claim.v2.ClaimMessageResponse claim_message_response = 2;
+}
+
+message ClaimSettlementExtraInfoErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message ClaimSettlementExtraInfoResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.claim.v2.ClaimSettlementExtraInfoSuccessResponse success_response = 1;
+    cmp.services.claim.v2.ClaimSettlementExtraInfoErrorResponse error_response = 2;
+  }
 }

--- a/proto/cmp/services/claim/v2/get_claim_form.proto
+++ b/proto/cmp/services/claim/v2/get_claim_form.proto
@@ -31,10 +31,23 @@ message ClaimGetFormRequest {
   // (you can add the report itself later in the submit_claim_form message). Could this be a type of claim?
 }
 
-message ClaimGetFormResponse {
+message ClaimGetFormSuccessResponse {
   // Message header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Claim form
   cmp.services.claim.v2.ClaimForm form = 2;
+}
+
+message ClaimGetFormErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message ClaimGetFormResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.claim.v2.ClaimGetFormSuccessResponse success_response = 1;
+    cmp.services.claim.v2.ClaimGetFormErrorResponse error_response = 2;
+  }
 }

--- a/proto/cmp/services/claim/v2/submit_claim_form.proto
+++ b/proto/cmp/services/claim/v2/submit_claim_form.proto
@@ -19,13 +19,26 @@ message ClaimSubmitFormRequest {
   cmp.services.claim.v2.ClaimForm form = 2;
 }
 
-message ClaimSubmitFormResponse {
+message ClaimSubmitFormSuccessResponse {
   // Message header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Claim Message Response to respond with claim ids (processing, carrier and submission) and message status
   cmp.services.claim.v2.ClaimMessageResponse claim_message_response = 2;
 
   // Claim Status
   cmp.services.claim.v2.ClaimStatus status = 3;
+}
+
+message ClaimSubmitFormErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message ClaimSubmitFormResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.claim.v2.ClaimSubmitFormSuccessResponse success_response = 1;
+    cmp.services.claim.v2.ClaimSubmitFormErrorResponse error_response = 2;
+  }
 }

--- a/proto/cmp/services/claim/v2/submit_claim_form_extra_info.proto
+++ b/proto/cmp/services/claim/v2/submit_claim_form_extra_info.proto
@@ -25,13 +25,26 @@ message ClaimSubmitFormExtraInfoRequest {
   }];
 }
 
-message ClaimSubmitFormExtraInfoResponse {
+message ClaimSubmitFormExtraInfoSuccessResponse {
   // Message header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Claim Message Response to respond with claim ids (processing, carrier and submission) and message status
   cmp.services.claim.v2.ClaimMessageResponse claim_message_response = 2;
 
   // Claim Status
   cmp.services.claim.v2.ClaimStatus status = 3;
+}
+
+message ClaimSubmitFormExtraInfoErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message ClaimSubmitFormExtraInfoResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.claim.v2.ClaimSubmitFormExtraInfoSuccessResponse success_response = 1;
+    cmp.services.claim.v2.ClaimSubmitFormExtraInfoErrorResponse error_response = 2;
+  }
 }

--- a/proto/cmp/services/info/v3/entry_requirements.proto
+++ b/proto/cmp/services/info/v3/entry_requirements.proto
@@ -85,9 +85,9 @@ message CountryEntryRequirementsRequest {
   bool include_items = 11;
 }
 
-message CountryEntryRequirementsResponse {
+message CountryEntryRequirementsSuccessResponse {
   // Message header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // This must be a UUID according to RFC 4122
   cmp.types.v4.UUID response_id = 2 [(buf.validate.field).required = true];
@@ -103,6 +103,19 @@ message CountryEntryRequirementsResponse {
     min_items: 0
     max_items: 10000
   }];
+}
+
+message CountryEntryRequirementsErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message CountryEntryRequirementsResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.info.v3.CountryEntryRequirementsSuccessResponse success_response = 1;
+    cmp.services.info.v3.CountryEntryRequirementsErrorResponse error_response = 2;
+  }
 }
 
 // Types

--- a/proto/cmp/services/insurance/v3/info.proto
+++ b/proto/cmp/services/insurance/v3/info.proto
@@ -35,15 +35,28 @@ message InsuranceProductInfoRequest {
   }];
 }
 
-message InsuranceProductInfoResponse {
+message InsuranceProductInfoSuccessResponse {
   // Message header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Product list: Insurances
   repeated cmp.services.insurance.v3.PolicyExtendedInfo insurances = 2 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100
   }];
+}
+
+message InsuranceProductInfoErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message InsuranceProductInfoResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.insurance.v3.InsuranceProductInfoSuccessResponse success_response = 1;
+    cmp.services.insurance.v3.InsuranceProductInfoErrorResponse error_response = 2;
+  }
 }
 
 // Insurance product info service definition

--- a/proto/cmp/services/insurance/v3/list.proto
+++ b/proto/cmp/services/insurance/v3/list.proto
@@ -19,15 +19,28 @@ message InsuranceProductListRequest {
   google.protobuf.Timestamp modified_after = 2;
 }
 
-message InsuranceProductListResponse {
+message InsuranceProductListSuccessResponse {
   // Message header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Product list: Insurance
   repeated cmp.services.insurance.v3.Insurance insurances = 2 [(buf.validate.field).repeated = {
     min_items: 0
     max_items: 100
   }];
+}
+
+message InsuranceProductListErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message InsuranceProductListResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.insurance.v3.InsuranceProductListSuccessResponse success_response = 1;
+    cmp.services.insurance.v3.InsuranceProductListErrorResponse error_response = 2;
+  }
 }
 
 // This service is used to get a product list for insurances.

--- a/proto/cmp/services/insurance/v3/search.proto
+++ b/proto/cmp/services/insurance/v3/search.proto
@@ -74,10 +74,10 @@ message InsuranceSearchRequest {
 // bookable option responded. Included, compulsory and optional services can be
 // included. A simple "free cancellation upto" can be set or full cancellation
 // policies can be included.
-message InsuranceSearchResponse {
+message InsuranceSearchSuccessResponse {
   // Message header. Contains API version, message info string and end user wallet
   // address.
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Search_id to be used in subsequent requests like the "Validation Request".
   cmp.types.v4.UUID search_id = 2 [(buf.validate.field).required = true];
@@ -93,6 +93,19 @@ message InsuranceSearchResponse {
     min_items: 0
     max_items: 15
   }];
+}
+
+message InsuranceSearchErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message InsuranceSearchResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.insurance.v3.InsuranceSearchSuccessResponse success_response = 1;
+    cmp.services.insurance.v3.InsuranceSearchErrorResponse error_response = 2;
+  }
 }
 
 // Service definition for Insurance search

--- a/proto/cmp/services/ping/v2/ping.proto
+++ b/proto/cmp/services/ping/v2/ping.proto
@@ -25,9 +25,9 @@ message PingRequest {
   google.protobuf.Timestamp timestamp = 3 [(buf.validate.field).required = true];
 }
 
-message PingResponse {
+message PingSuccessResponse {
   // Message Header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Ping message
   string message = 2 [(buf.validate.field).string.max_bytes = 512];
@@ -38,6 +38,19 @@ message PingResponse {
   // For on-chain operations, only seconds are supported, and nanoseconds
   // will be ignored.
   google.protobuf.Timestamp timestamp = 3 [(buf.validate.field).required = true];
+}
+
+message PingErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message PingResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.ping.v2.PingSuccessResponse success_response = 1;
+    cmp.services.ping.v2.PingErrorResponse error_response = 2;
+  }
 }
 
 // The Ping Service definition

--- a/proto/cmp/services/seat_map/v4/availability.proto
+++ b/proto/cmp/services/seat_map/v4/availability.proto
@@ -106,17 +106,30 @@ message SeatMapAvailabilityRequest {
   }
 }
 
+message SeatMapAvailabilitySuccessResponse {
+  // Message header
+  //
+  // Header contains information about the response
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
+
+  // Required. Seat map availability data.
+  cmp.types.v4.SeatMapInventory seat_map = 2;
+}
+
+message SeatMapAvailabilityErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
 // Response for seat map availability request
 //
 // Contains the seat map availability data for a given map ID
 message SeatMapAvailabilityResponse {
-  // Message header
-  //
-  // Header contains information about the response
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
-
-  // Required. Seat map availability data.
-  cmp.types.v4.SeatMapInventory seat_map = 2;
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.seat_map.v4.SeatMapAvailabilitySuccessResponse success_response = 1;
+    cmp.services.seat_map.v4.SeatMapAvailabilityErrorResponse error_response = 2;
+  }
 }
 
 // Service for requesting seat map availability data

--- a/proto/cmp/services/seat_map/v4/seat_map.proto
+++ b/proto/cmp/services/seat_map/v4/seat_map.proto
@@ -36,19 +36,32 @@ message SeatMapRequest {
   }];
 }
 
-// Response for seat map request
-//
-// Contains the seat map data for a given map ID
-message SeatMapResponse {
+message SeatMapSuccessResponse {
   // Response header
   //
   // Header contains information about the response
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Seat map data
   //
   // Contains the seat map data for the requested map ID
   cmp.types.v4.SeatMap seat_map = 2;
+}
+
+message SeatMapErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+// Response for seat map request
+//
+// Contains the seat map data for a given map ID
+message SeatMapResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.seat_map.v4.SeatMapSuccessResponse success_response = 1;
+    cmp.services.seat_map.v4.SeatMapErrorResponse error_response = 2;
+  }
 }
 
 // Service for requesting seat map data for a given map ID

--- a/proto/cmp/services/transport/v4/list.proto
+++ b/proto/cmp/services/transport/v4/list.proto
@@ -19,12 +19,25 @@ message TransportProductListRequest {
   google.protobuf.Timestamp modified_after = 2;
 }
 
-message TransportProductListResponse {
+message TransportProductListSuccessResponse {
   // Message header
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Product list: Trips
   repeated cmp.services.transport.v4.TripBasic trips = 2;
+}
+
+message TransportProductListErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message TransportProductListResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.transport.v4.TransportProductListSuccessResponse success_response = 1;
+    cmp.services.transport.v4.TransportProductListErrorResponse error_response = 2;
+  }
 }
 
 // This service is used to get a product list for transportation.

--- a/proto/cmp/services/transport/v4/search.proto
+++ b/proto/cmp/services/transport/v4/search.proto
@@ -38,10 +38,10 @@ message TransportSearchRequest {
   }];
 }
 
-message TransportSearchResponse {
+message TransportSearchSuccessResponse {
   // Message header. Contains API version, message info string and end-user wallet
   // address
-  cmp.types.v4.ResponseHeader header = 1 [(buf.validate.field).required = true];
+  cmp.types.v4.SuccessResponseHeader header = 1 [(buf.validate.field).required = true];
 
   // Search_id to be used in subsequent requests like the "Validation Request".
   cmp.types.v4.ExpiringUUID search_id = 2 [(buf.validate.field).required = true];
@@ -74,6 +74,19 @@ message TransportSearchResponse {
     min_items: 0
     max_items: 15
   }];
+}
+
+message TransportSearchErrorResponse {
+  // Common error response header used in every error response.
+  cmp.types.v4.ErrorResponseHeader header = 1 [(buf.validate.field).required = true];
+}
+
+message TransportSearchResponse {
+  oneof response {
+    option (buf.validate.oneof).required = true; // One must be provided
+    cmp.services.transport.v4.TransportSearchSuccessResponse success_response = 1;
+    cmp.services.transport.v4.TransportSearchErrorResponse error_response = 2;
+  }
 }
 
 // Transport Search Service definition.

--- a/proto/cmp/types/v4/common.proto
+++ b/proto/cmp/types/v4/common.proto
@@ -123,7 +123,7 @@ message Alert {
 
   // The optional human-readable alert message to further specify the alert.
   string message = 1 [(buf.validate.field).string = {
-    min_len: 0 // Message cannot be empty.
+    min_len: 0
     max_bytes: 512 // Constrains message length.
   }];
 }
@@ -135,8 +135,7 @@ enum AlertCode {
   ALERT_CODE_NO_CONTENT = 1;
   ALERT_CODE_DEPRECATED_VERSION = 2; // The version used is deprecated and may not be supported in the future.
   ALERT_CODE_LANGUAGE_NOT_SUPPORTED = 3; // One or more requested languages are not supported.
-  ALERT_CODE_CURRENCY_NOT_SUPPORTED = 4; // One or more requested currencies are not supported.
-  ALERT_CODE_INFORMATIONAL = 5; // An informational alert that does not indicate an error or warning.
+  ALERT_CODE_INFORMATIONAL = 4; // An informational alert that does not indicate an error or warning.
 }
 
 // Errors provides detailed feedback about why a request failed.
@@ -156,9 +155,10 @@ enum ErrorCode {
   ERROR_CODE_UNSPECIFIED = 0;
   ERROR_CODE_INVALID_PROTO = 1; // The request did not conform to the expected Protobuf schema and/or validation rules.
   ERROR_CODE_INVALID_IDENTIFIERS = 2; // The request contained invalid or unrecognized identifiers (e.g. ExpiringUUIDs).
-  ERROR_CODE_UNIMPLEMENTED = 3; // The request contained fields which are not supported (and can't be ignored).
-  ERROR_CODE_UNAUTHORIZED = 4; // The requester is not authorized to perform the operation.
-  ERROR_CODE_INTERNAL = 5; // An internal server error occurred.
-  ERROR_CODE_TEMPORARY_UNAVAILABLE = 6; // The service is temporarily unavailable.
-  ERROR_CODE_RATE_LIMIT_EXCEEDED = 7; // The request exceeded the allowed rate limit.
+  ERROR_CODE_INVALID_CURRENCY = 3; // The request contained invalid or unsupported currency codes.
+  ERROR_CODE_UNIMPLEMENTED = 4; // The request contained fields which are not supported (and can't be ignored).
+  ERROR_CODE_UNAUTHORIZED = 5; // The requester is not authorized to perform the operation.
+  ERROR_CODE_INTERNAL = 6; // An internal server error occurred.
+  ERROR_CODE_TEMPORARY_UNAVAILABLE = 7; // The service is temporarily unavailable.
+  ERROR_CODE_RATE_LIMIT_EXCEEDED = 8; // The request exceeded the allowed rate limit.
 }

--- a/proto/cmp/types/v4/common.proto
+++ b/proto/cmp/types/v4/common.proto
@@ -136,8 +136,7 @@ enum AlertCode {
   ALERT_CODE_DEPRECATED_VERSION = 2; // The version used is deprecated and may not be supported in the future.
   ALERT_CODE_LANGUAGE_NOT_SUPPORTED = 3; // One or more requested languages are not supported.
   ALERT_CODE_CURRENCY_NOT_SUPPORTED = 4; // One or more requested currencies are not supported.
-  ALERT_CODE_RATE_LIMIT_EXCEEDED = 5; // The request exceeded the allowed rate limit.
-  ALERT_CODE_INFORMATIONAL = 6; // An informational alert that does not indicate an error or warning.
+  ALERT_CODE_INFORMATIONAL = 5; // An informational alert that does not indicate an error or warning.
 }
 
 // Errors provides detailed feedback about why a request failed.

--- a/proto/cmp/types/v4/common.proto
+++ b/proto/cmp/types/v4/common.proto
@@ -91,57 +91,75 @@ message RequestHeader {
   cmp.types.v4.Header base_header = 1 [(buf.validate.field).required = true];
 }
 
-// ResponseHeader wraps the common base header and includes response-specific info.
-message ResponseHeader {
+// The SuccessResponseHeader wraps the common base header and includes response-specific info.
+message SuccessResponseHeader {
   // The base header information common to all CMP messages.
   cmp.types.v4.Header base_header = 1 [(buf.validate.field).required = true];
 
-  // Overall status of the response (e.g., success or failure).
-  // An indication of failure is only applicable in case the requested operation
-  // can't be executed. For instance if the input is invalid.
-  // If all inputs are valid and the operation itself was successful but returned
-  // no results, this is still a successful operation and must still be
-  // considered successful in this context.
-  // In this case an alert may be included indicating what lead to the
-  // result being empty.
-  cmp.types.v4.StatusType status = 2 [(buf.validate.field).enum = {
-    defined_only: true // Ensures only defined enum values are used.
-    not_in: [0] /* Disallows STATUS_TYPE_UNSPECIFIED. */
-  }];
-
-  // A list of alerts providing more detailed information about the
-  // response, such as informational messages, warnings, or specific errors.
-  // In case of a failure, alerts must provide insights into the issue.
-  repeated cmp.types.v4.Alert alerts = 3 [(buf.validate.field).repeated = {max_items: 25}];
+  // A list of alerts providing more detailed information about the response
+  repeated cmp.types.v4.Alert alerts = 2 [(buf.validate.field).repeated = {max_items: 25}];
 }
 
-// Alert provides detailed feedback, which can be an error, warning, or
+// The ErrorResponseHeader wraps the common base header and includes reasons for failure.
+message ErrorResponseHeader {
+  // The base header information common to all CMP messages.
+  cmp.types.v4.Header base_header = 1 [(buf.validate.field).required = true];
+
+  // A list of errors providing more detailed information about the
+  // response failure.
+  repeated cmp.types.v4.Error errors = 2 [(buf.validate.field).repeated = {
+    min_items: 1
+    max_items: 25
+  }];
+}
+
+// Alert provides detailed feedback which can be a warning, or
 // informational message.
 message Alert {
-  // The human-readable alert message.
+  cmp.types.v4.AlertCode code = 3 [(buf.validate.field).enum = {
+    defined_only: true // Ensures only defined enum values are used.
+    not_in: [0] /* Disallows ALERT_CODE_UNSPECIFIED. */
+  }];
+
+  // The optional human-readable alert message to further specify the alert.
   string message = 1 [(buf.validate.field).string = {
-    min_len: 1 // Message cannot be empty.
+    min_len: 0 // Message cannot be empty.
     max_bytes: 512 // Constrains message length.
   }];
+}
 
-  // The type or severity of the alert.
-  cmp.types.v4.AlertType type = 2 [(buf.validate.field).enum = {
+enum AlertCode {
+  ALERT_CODE_UNSPECIFIED = 0;
+  // The request was successful but there is no content to return.
+  // This can be due to filters or criteria that resulted in no matching data.
+  ALERT_CODE_NO_CONTENT = 1;
+  ALERT_CODE_DEPRECATED_VERSION = 2; // The version used is deprecated and may not be supported in the future.
+  ALERT_CODE_LANGUAGE_NOT_SUPPORTED = 3; // One or more requested languages are not supported.
+  ALERT_CODE_CURRENCY_NOT_SUPPORTED = 4; // One or more requested currencies are not supported.
+  ALERT_CODE_RATE_LIMIT_EXCEEDED = 5; // The request exceeded the allowed rate limit.
+  ALERT_CODE_INFORMATIONAL = 6; // An informational alert that does not indicate an error or warning.
+}
+
+// Errors provides detailed feedback about why a request failed.
+message Error {
+  cmp.types.v4.ErrorCode code = 1 [(buf.validate.field).enum = {
     defined_only: true // Ensures only defined enum values are used.
-    not_in: [0] /* Disallows ALERT_TYPE_UNSPECIFIED. */
+    not_in: [0] /* Disallows ERROR_CODE_UNSPECIFIED. */
+  }];
+
+  // An optional human-readable error message to further specify the error.
+  string message = 2 [(buf.validate.field).string = {
+    max_bytes: 512 // Constrains message length.
   }];
 }
 
-// AlertType categorizes the nature of an alert.
-enum AlertType {
-  ALERT_TYPE_UNSPECIFIED = 0; // Default, should not be used.
-  ALERT_TYPE_INFO = 1; // Informational message.
-  ALERT_TYPE_WARNING = 2; // Warning that might not be critical but indicates a potential issue.
-  ALERT_TYPE_ERROR = 3; // Error indicating a failure or problem.
-}
-
-// StatusType indicates the overall outcome of a response.
-enum StatusType {
-  STATUS_TYPE_UNSPECIFIED = 0; // Default, should not be used.
-  STATUS_TYPE_SUCCESS = 1; // Indicates the operation was successful.
-  STATUS_TYPE_FAILURE = 2; // Indicates the operation failed.
+enum ErrorCode {
+  ERROR_CODE_UNSPECIFIED = 0;
+  ERROR_CODE_INVALID_PROTO = 1; // The request did not conform to the expected Protobuf schema and/or validation rules.
+  ERROR_CODE_INVALID_IDENTIFIERS = 2; // The request contained invalid or unrecognized identifiers (e.g. ExpiringUUIDs).
+  ERROR_CODE_UNIMPLEMENTED = 3; // The request contained fields which are not supported (and can't be ignored).
+  ERROR_CODE_UNAUTHORIZED = 4; // The requester is not authorized to perform the operation.
+  ERROR_CODE_INTERNAL = 5; // An internal server error occurred.
+  ERROR_CODE_TEMPORARY_UNAVAILABLE = 6; // The service is temporarily unavailable.
+  ERROR_CODE_RATE_LIMIT_EXCEEDED = 7; // The request exceeded the allowed rate limit.
 }


### PR DESCRIPTION
* Restructuring of the response messages by splitting it up into success and error response to be proto-valid even in error cases. 
* Made warning,info and error types more specific (and clear) by introducing enums for them.