### PR TITLE
Error codes and date ranges

### DIFF
--- a/proto/cmp/types/v4/common.proto
+++ b/proto/cmp/types/v4/common.proto
@@ -161,4 +161,9 @@ enum ErrorCode {
   ERROR_CODE_INTERNAL = 6; // An internal server error occurred.
   ERROR_CODE_TEMPORARY_UNAVAILABLE = 7; // The service is temporarily unavailable.
   ERROR_CODE_RATE_LIMIT_EXCEEDED = 8; // The request exceeded the allowed rate limit.
+  // An error occurred in the context of the overall business process.
+  // This could involve issues like proto-valid field values which are invalid in the context of the process
+  // payment failures, or other domain-specific errors.
+  ERROR_CODE_BUSINESS_PROCESS_ERROR = 9;
+  ERROR_CODE_BLOCKCHAIN_ERROR = 10; // An error occurred while interacting with the blockchain.
 }

--- a/proto/cmp/types/v4/datetime_range.proto
+++ b/proto/cmp/types/v4/datetime_range.proto
@@ -23,8 +23,14 @@ message DateTimeRange {
   // truncated by the blockchain.
   google.protobuf.Timestamp start = 1 [(buf.validate.field).required = true];
 
-  // The inclusive end date and time of the range. It is expected that `end` is
+  // The **exclusive** end date and time of the range. It is expected that `end` is
   // later than or equal to `start`.
+  // The end date is exclusive because it allows for representing ranges that
+  // naturally align with common time intervals. For example, a range from
+  // `2024-01-01T00:00:00Z` to `2024-01-02T00:00:00Z` clearly indicates that the range
+  // includes all moments on January 1st, 2024, but does not include any part of
+  // January 2nd, 2024. This exclusivity is particularly useful in scheduling
+  // and booking systems where end times often signify the start of a new period.
   //
   // Similar to `start`, this timestamp can be used for both off-chain and on-chain
   // operations. For on-chain use, nanosecond precision may not be supported, with


### PR DESCRIPTION
* Added more error codes for blockchain or business related issues. 
* Changed the definition of the date time range end date to be exclusive to prevent undefined behavior in defining time-frames without gaps in-between.